### PR TITLE
work around "Class constructor cannot be invoked without 'new'" problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-router-dom": "^4.0.0",
     "react-router-redux": "next",
     "redux": "^3.6.0",
-    "redux-orm": "^0.9.0-rc.3",
+    "redux-orm": "Hylozoic/redux-orm#model-createClass-dist",
     "redux-promise": "^0.5.3",
     "redux-thunk": "^2.2.0",
     "replacestream": "^4.0.2",

--- a/src/store/models/Comment.js
+++ b/src/store/models/Comment.js
@@ -1,10 +1,18 @@
 import { attr, fk, Model } from 'redux-orm'
 
-export default class Comment extends Model {
+const Comment = Model.createClass({
   toString () {
     return `Comment: ${this.name}`
   }
-}
+})
+
+export default Comment
+
+// export default class Comment extends Model {
+//   toString () {
+//     return `Comment: ${this.name}`
+//   }
+// }
 
 Comment.modelName = 'Comment'
 

--- a/src/store/models/Community.js
+++ b/src/store/models/Community.js
@@ -1,10 +1,12 @@
 import { attr, many, Model } from 'redux-orm'
 
-export default class Community extends Model {
+const Community = Model.createClass({
   toString () {
     return `Community: ${this.name}`
   }
-}
+})
+
+export default Community
 
 Community.modelName = 'Community'
 

--- a/src/store/models/Community.test.js
+++ b/src/store/models/Community.test.js
@@ -1,0 +1,11 @@
+import orm from 'store/models' // this initializes redux-orm
+
+it('can be created', () => {
+  const community = {id: '1'}
+  const session = orm.session(orm.getEmptyState())
+  session.Community.create(community)
+
+  const { Community: { items, itemsById } } = session.state
+  expect(items).toEqual([community.id])
+  expect(itemsById[community.id]).toEqual(community)
+})

--- a/src/store/models/FeedItem.js
+++ b/src/store/models/FeedItem.js
@@ -1,10 +1,12 @@
 import { attr, fk, Model } from 'redux-orm'
 
-export default class FeedItem extends Model {
+const FeedItem = Model.createClass({
   toString () {
     return `Post: ${this.name}`
   }
-}
+})
+
+export default FeedItem
 
 FeedItem.modelName = 'FeedItem'
 FeedItem.fields = {

--- a/src/store/models/Me.js
+++ b/src/store/models/Me.js
@@ -1,10 +1,12 @@
 import { attr, many, Model } from 'redux-orm'
 
-export default class Me extends Model {
+const Me = Model.createClass({
   toString () {
     return `Me: ${this.name}`
   }
-}
+})
+
+export default Me
 
 Me.modelName = 'Me'
 Me.fields = {

--- a/src/store/models/Membership.js
+++ b/src/store/models/Membership.js
@@ -1,10 +1,12 @@
 import { attr, fk, Model } from 'redux-orm'
 
-export default class Membership extends Model {
+const Membership = Model.createClass({
   toString () {
     return `Membership: ${this.id}`
   }
-}
+})
+
+export default Membership
 
 Membership.modelName = 'Membership'
 Membership.fields = {

--- a/src/store/models/Person.js
+++ b/src/store/models/Person.js
@@ -1,10 +1,12 @@
 import { attr, Model } from 'redux-orm'
 
-export default class Person extends Model {
+const Person = Model.createClass({
   toString () {
     return `Person: ${this.name}`
   }
-}
+})
+
+export default Person
 
 Person.modelName = 'Person'
 

--- a/src/store/models/Post.js
+++ b/src/store/models/Post.js
@@ -1,24 +1,26 @@
 import { attr, fk, many, Model } from 'redux-orm'
 
-export class PostFollower extends Model {}
+export const PostFollower = Model.createClass({})
 PostFollower.modelName = 'PostFollower'
 PostFollower.fields = {
   post: fk('Post', 'postfollowers'),
   follower: fk('Person', 'postfollowers')
 }
 
-export class PostCommenter extends Model {}
+export const PostCommenter = Model.createClass({})
 PostCommenter.modelName = 'PostCommenter'
 PostCommenter.fields = {
   post: fk('Post', 'postcommenters'),
   commenter: fk('Person', 'postcommenters')
 }
 
-export default class Post extends Model {
+const Post = Model.createClass({
   toString () {
     return `Post: ${this.name}`
   }
-}
+})
+
+export default Post
 
 Post.modelName = 'Post'
 Post.fields = {

--- a/src/store/reducers/ormReducer.js
+++ b/src/store/reducers/ormReducer.js
@@ -37,7 +37,7 @@ export default function ormReducer (state = {}, action) {
 
     case a.FETCH_POSTS:
       const { id, posts } = payload.data.community
-      const community = Community.get({id})
+      const community = Community.withId(id)
       community.update({
         feedOrder: (community.feedOrder || []).concat(posts.map(f => f.id))
       })
@@ -48,7 +48,9 @@ export default function ormReducer (state = {}, action) {
 }
 
 function addEntity (payload) {
-  return model => model.hasId(payload.id) ? model.withId(payload.id).update(payload) : model.create(payload)
+  return model => model.hasId(payload.id)
+    ? model.withId(payload.id).update(payload)
+    : model.create(payload)
 }
 
 function deleteEntity (payload) {

--- a/src/store/reducers/ormReducer.test.js
+++ b/src/store/reducers/ormReducer.test.js
@@ -1,0 +1,65 @@
+import orm from 'store/models' // this initializes redux-orm
+import ormReducer from './ormReducer'
+import { ADD_PERSON, UPDATE_PERSON, FETCH_POSTS } from 'store/constants'
+
+describe('ADD_PERSON', () => {
+  it('adds a person to app state', () => {
+    const person = {id: '1', name: 'Lolo'}
+    const state = orm.getEmptyState()
+    const action = {type: ADD_PERSON, payload: person}
+
+    const { Person: { itemsById, items } } = ormReducer(state, action)
+    expect(itemsById[person.id]).toEqual(person)
+    expect(items).toEqual([person.id])
+  })
+})
+
+describe('UPDATE_PERSON', () => {
+  let state
+
+  beforeEach(() => {
+    const session = orm.session(orm.getEmptyState())
+    session.Person.create({id: '1'})
+    state = session.state
+  })
+
+  it('updates a person in app state', () => {
+    const person = {id: '1', name: 'Lolo'}
+    const action = {type: UPDATE_PERSON, payload: person}
+
+    const { Person: { itemsById, items } } = ormReducer(state, action)
+    expect(itemsById[person.id]).toEqual(person)
+    expect(items).toEqual([person.id])
+  })
+})
+
+describe('FETCH_POSTS', () => {
+  let state
+
+  beforeEach(() => {
+    const session = orm.session(orm.getEmptyState())
+    session.Community.create({id: '1'})
+    state = session.state
+  })
+
+  it('adds feedOrder to community', () => {
+    const action = {
+      type: FETCH_POSTS,
+      payload: {
+        data: {
+          community: {
+            id: '1',
+            posts: [
+              {id: 1}, {id: 5}, {id: 2}, {id: 4}, {id: 3}
+            ]
+          }
+        }
+      }
+    }
+    const nextState = ormReducer(state, action)
+    expect(nextState.Community.itemsById['1']).toEqual({
+      id: '1',
+      feedOrder: [1, 5, 2, 4, 3]
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4588,11 +4588,11 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@4.1.0, object-assign@^4.1.0:
+object-assign@4.1.0, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-assign@^4.0.1, object-assign@^4.1.1:
+object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -5781,9 +5781,9 @@ redux-mock-store@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.2.2.tgz#38007dc38f12ca8d965c7521afee5ccacc234d03"
 
-redux-orm@^0.9.0-rc.3:
+redux-orm@Hylozoic/redux-orm#model-createClass-dist:
   version "0.9.0-rc.3"
-  resolved "https://registry.yarnpkg.com/redux-orm/-/redux-orm-0.9.0-rc.3.tgz#48e3f6984d104e09734ad6a006376ee791841682"
+  resolved "https://codeload.github.com/Hylozoic/redux-orm/tar.gz/ef12967163e79b492df76449874c42fd01559459"
   dependencies:
     babel-runtime "^6.6.1"
     immutable-ops "^0.5.2"


### PR DESCRIPTION
forked redux-orm and added a Model.createClass function which allows us
to create our models without using ES6 classes

original issue: https://github.com/tommikaikkonen/redux-orm/issues/53
our pull request: https://github.com/tommikaikkonen/redux-orm/pull/116
