### PR TITLE
fix for draft-js css to get included in prod

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -133,10 +133,18 @@ module.exports = {
         include: paths.appSrc,
         loader: 'babel-loader'
       },
-
+      // Simple CSS loading for node_modules fond CSS (need in particular for draft-js-plugins-editor styles)
+      {
+        test: /draft-js.*\.css$/,
+        use: [
+          'style-loader',
+          'css-loader'
+        ]
+      },
       // CSS Modules for all SASS files not in resources or global
       {
         test: /\.(css|scss|sass)$/,
+        exclude: /draft-js.*\.css$/,
         loader: ExtractTextPlugin.extract(Object.assign({
           fallback: 'style-loader',
           use: [


### PR DESCRIPTION
see notes about this issue here:
https://trello.com/c/NvvSPFcn/315-comment-editor-height-is-wrong-only-in-production

@lorenjohnson I just brought in the config from dev, is that ok/right?