### PR TITLE
Don't offer to message self if current user

### DIFF
--- a/src/components/MessageMember/MessageMember.connector.js
+++ b/src/components/MessageMember/MessageMember.connector.js
@@ -6,8 +6,9 @@ import getPerson from 'store/selectors/getPerson'
 export function mapStateToProps (state, props) {
   const member = getPerson(state, {personId: getParam('id', state, props)})
   const currentUser = getMe(state, props)
+  const isMe = currentUser && currentUser.id === member.id
   return {
-    currentUserId: currentUser.id,
+    isMe,
     member
   }
 }

--- a/src/components/MessageMember/MessageMember.js
+++ b/src/components/MessageMember/MessageMember.js
@@ -5,17 +5,16 @@ import Button from 'components/Button'
 import { messagesUrl } from 'util/index'
 import './MessageMember.scss'
 
-export default function MessageMember ({ currentUserId, member }) {
+export default function MessageMember ({ isMe, member }) {
   if (!member) return <Loading />
   const { messageThreadId } = member
-  const isCurrentUser = currentUserId && currentUserId === member.id
 
   const path = messageThreadId
     ? `/t/${messageThreadId}`
     : `/t/new?participants=${member.id}`
 
   return <div styleName='container'>
-    {isCurrentUser
+    {isMe
       ? <Link to={messagesUrl()}>
         <Button styleName='message-member'>Messages</Button>
       </Link>


### PR DESCRIPTION
Trello: https://trello.com/c/1LpUuWKt/428-evo-personal-profile-shouldnt-show-message-button-to-non-existent-thread-with-self

If viewing your own profile, this shows a 'Messages' button which links to the messages display instead of a 'Message' button which attempts to start a new thread with yourself.