### PR TITLE
resets atTabBar when loading new posts

### DIFF
--- a/src/components/FeedList/FeedList.js
+++ b/src/components/FeedList/FeedList.js
@@ -44,6 +44,13 @@ export default class FeedList extends React.Component {
     }
   })
 
+  componentWillReceiveProps (nextProps) {
+    if (isEmpty(nextProps.posts)) {
+      // Resets atTabBar when loading new posts since it jumps to top without a scrollEvent
+      this.setState({atTabBar: false})
+    }
+  }
+
   componentDidMount () {
     this.fetchOrShowCached()
   }


### PR DESCRIPTION
https://trello.com/c/CaG9Yaa0/475-clicking-tabbar-on-feedlist-jumps-to-top-of-page-and-then-shows-a-duplicate-tabbar