### PR TITLE
WEB-77 - remove ui kits and other dev features

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -203,7 +203,8 @@ module.exports = {
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         screw_ie8: true, // React doesn't support IE8
-        warnings: false
+        warnings: false,
+        drop_console: true
       },
       mangle: {
         screw_ie8: true


### PR DESCRIPTION
This PR suppresses console.logging in production via Webpack applied Uglify. Does the trick well.