### PR TITLE
WEB617 Raw-loader for Markdown

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -14,7 +14,14 @@ module.exports = async ({ config }) => {
     },
     module: {
       ...config.module,
-      rules: hyloWebpackConfig.module.rules
+      rules: [
+        // import Markdown raw
+        {
+          test: /\.md$/,
+          use: 'raw-loader'
+        },
+        ...hyloWebpackConfig.module.rules
+      ]
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "prop-types": "^15.6.0",
     "pushstate-server": "^3.0.0",
     "raf": "^3.4.0",
+    "raw-loader": "^2.0.0",
     "react": "^16.8.6",
     "react-app-polyfill": "^0.2.2",
     "react-autocomplete": "^1.7.2",


### PR DESCRIPTION
Here's the markdown loader for Storybook @philipbeadle. I'm assuming you wanted it as a raw string for use with Storybook rather than compiled to html.