### PR TITLE
Fix notifications load failing on multiple community posts

### DIFF
--- a/src/routes/PrimaryLayout/components/TopNav/NotificationsDropdown/NotificationsDropdown.store.js
+++ b/src/routes/PrimaryLayout/components/TopNav/NotificationsDropdown/NotificationsDropdown.store.js
@@ -36,6 +36,7 @@ export function fetchNotifications () {
                 id
                 title
                 communities {
+                  id
                   slug
                 }
               }


### PR DESCRIPTION
Due to requirements of ReduxORM pulling-in Post.communities slugs without also pulling in the IDs breaks things. Added ID to the graphql query and it fixed the breaking notification entries on @tibetsprague's login (tested locally with a snapshot of prod data). 

Note that the issue with creating new comments is fixed in this backend branch which is also tested and ready to go:

https://github.com/Hylozoic/hylo-node/pull/493