### PR TITLE
Event invitee options scoped by selected communities

### DIFF
--- a/src/components/EventInviteDialog/EventInviteDialog.connector.js
+++ b/src/components/EventInviteDialog/EventInviteDialog.connector.js
@@ -17,7 +17,7 @@ export function mapDispatchToProps (dispatch, props) {
     ...bindActionCreators({
       invitePeopleToEvent
     }, dispatch),
-    fetchPeople: debounce(300, opts => dispatch(fetchPeople(opts)))
+    fetchPeople: debounce(300, (...args) => dispatch(fetchPeople(...args)))
   }
 }
 

--- a/src/components/EventInviteDialog/EventInviteDialog.connector.js
+++ b/src/components/EventInviteDialog/EventInviteDialog.connector.js
@@ -1,4 +1,6 @@
 import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import { debounce } from 'lodash/fp'
 import fetchPeople from 'store/actions/fetchPeople'
 import { invitePeopleToEvent, peopleSelector } from './EventInviteDialog.store'
 
@@ -10,8 +12,13 @@ export function mapStateToProps (state, props) {
   }
 }
 
-export const mapDispatchToProps = {
-  fetchPeople, invitePeopleToEvent
+export function mapDispatchToProps (dispatch, props) {
+  return {
+    ...bindActionCreators({
+      invitePeopleToEvent
+    }, dispatch),
+    fetchPeople: debounce(300, opts => dispatch(fetchPeople(opts)))
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)

--- a/src/components/EventInviteDialog/EventInviteDialog.connector.test.js
+++ b/src/components/EventInviteDialog/EventInviteDialog.connector.test.js
@@ -9,6 +9,6 @@ describe('mapStateToProps', () => {
 
 describe('mapDispatchToProps', () => {
   it('returns the right keys', () => {
-    expect(mapDispatchToProps).toMatchSnapshot()
+    expect(mapDispatchToProps()).toMatchSnapshot()
   })
 })

--- a/src/components/EventInviteDialog/EventInviteDialog.connector.test.js
+++ b/src/components/EventInviteDialog/EventInviteDialog.connector.test.js
@@ -2,7 +2,7 @@ import { mapStateToProps, mapDispatchToProps } from './EventInviteDialog.connect
 
 describe('mapStateToProps', () => {
   it('returns the right keys', () => {
-    const stateProps = mapStateToProps({})
+    const stateProps = mapStateToProps({}, { forCommunities: [] })
     expect(stateProps).toMatchSnapshot()
   })
 })

--- a/src/components/EventInviteDialog/EventInviteDialog.js
+++ b/src/components/EventInviteDialog/EventInviteDialog.js
@@ -29,8 +29,10 @@ export default class EventInviteDialog extends React.PureComponent {
   }
 
   onSearchChange = ({ target: { value } }) => {
+    const { fetchPeople, forCommunities } = this.props
+    const forCommunityIds = forCommunities.map(c => c.id)
     this.setState({ searchTerm: value })
-    this.props.fetchPeople(value)
+    fetchPeople(value, forCommunityIds)
   }
 
   getFilteredInviteSuggestions = () => {

--- a/src/components/EventInviteDialog/EventInviteDialog.js
+++ b/src/components/EventInviteDialog/EventInviteDialog.js
@@ -81,7 +81,12 @@ export default class EventInviteDialog extends React.PureComponent {
         </div>
         <div styleName='alreadyInvitedLabel'>Already Invited</div>
         <div styleName='alreadyInvited'>
-          {eventInvitations.map(eventInvitation => <InviteeRow person={eventInvitation} showResponse key={eventInvitation.id} />)}
+          {eventInvitations.map(eventInvitation =>
+            <InviteeRow
+              person={eventInvitation}
+              showResponse
+              key={eventInvitation.id}
+            />)}
         </div>
         <Button
           small

--- a/src/components/EventInviteDialog/EventInviteDialog.store.js
+++ b/src/components/EventInviteDialog/EventInviteDialog.store.js
@@ -1,27 +1,36 @@
 import { createSelector } from 'redux-orm'
 import orm from 'store/models'
-import { pick } from 'lodash/fp'
+import getMe from 'store/selectors/getMe'
+import { pick, uniqBy, orderBy, flow, reject, map, reduce } from 'lodash/fp'
 
 export const MODULE_NAME = 'EventInviteDialog'
 export const INVITE_PEOPLE_TO_EVENT = `${MODULE_NAME}/INVITE_PEOPLE_TO_EVENT`
 export const INVITE_PEOPLE_TO_EVENT_PENDING = `${INVITE_PEOPLE_TO_EVENT}_PENDING`
 
-export function presentPerson (person) {
-  return {
-    ...pick([ 'id', 'name', 'avatarUrl' ], person.ref),
-    community: person.memberships.first()
-      ? person.memberships.first().community.name : null
-  }
-}
-
 export const peopleSelector = createSelector(
   orm,
   state => state.orm,
-  session => session.Person.all()
-    .orderBy('name')
-    .toModelArray()
-    .map(presentPerson)
-)
+  getMe,
+  (_, props) => props.forCommunities,
+  (
+    { Community },
+    currentUser,
+    forCommunities
+  ) => {
+    const forCommunityIds = forCommunities.map(c => c.id)
+    const communities = Community
+      .filter(c => forCommunityIds ? forCommunityIds.includes(c.id) : true)
+      .toModelArray()
+    const processors = [
+      reduce((result, c) => result.concat(c.members.toModelArray()), []),
+      uniqBy('id'),
+      reject(p => currentUser ? currentUser.id === p.id : false),
+      map(pick([ 'id', 'name', 'avatarUrl' ])),
+      orderBy('name', 'asc')
+    ]
+    
+    return flow(processors)(communities)
+})
 
 export function invitePeopleToEvent (eventId, inviteeIds) {
   return {

--- a/src/components/EventInviteDialog/EventInviteDialog.store.js
+++ b/src/components/EventInviteDialog/EventInviteDialog.store.js
@@ -28,9 +28,10 @@ export const peopleSelector = createSelector(
       map(pick([ 'id', 'name', 'avatarUrl' ])),
       orderBy('name', 'asc')
     ]
-    
+
     return flow(processors)(communities)
-})
+  }
+)
 
 export function invitePeopleToEvent (eventId, inviteeIds) {
   return {

--- a/src/components/EventInviteDialog/EventInviteDialog.store.test.js
+++ b/src/components/EventInviteDialog/EventInviteDialog.store.test.js
@@ -1,27 +1,5 @@
 import { presentPerson, invitePeopleToEvent } from './EventInviteDialog.store'
 
-describe('presentPerson', () => {
-  it('extracts the right keys', () => {
-    const peopleModel = {
-      ref: {
-        id: 1,
-        name: 'jo',
-        avatarUrl: 'jo.png',
-        unusedField: 'yup'
-      },
-      memberships: {
-        first: () => ({
-          community: {
-            name: 'coomunity'
-          }
-        })
-      }
-    }
-
-    expect(presentPerson(peopleModel)).toMatchSnapshot()
-  })
-})
-
 describe('invitePeopleToEvent', () => {
   it('matches snapshot', () => {
     expect(invitePeopleToEvent(1, [2, 3, 4])).toMatchSnapshot()

--- a/src/components/EventInviteDialog/__snapshots__/EventInviteDialog.store.test.js.snap
+++ b/src/components/EventInviteDialog/__snapshots__/EventInviteDialog.store.test.js.snap
@@ -43,12 +43,3 @@ Object {
   "type": "EventInviteDialog/INVITE_PEOPLE_TO_EVENT",
 }
 `;
-
-exports[`presentPerson extracts the right keys 1`] = `
-Object {
-  "avatarUrl": "jo.png",
-  "community": "coomunity",
-  "id": 1,
-  "name": "jo",
-}
-`;

--- a/src/components/MemberSelector/MemberSelector.connector.js
+++ b/src/components/MemberSelector/MemberSelector.connector.js
@@ -2,23 +2,20 @@ import { connect } from 'react-redux'
 
 import fetchPeople from 'store/actions/fetchPeople'
 import {
-  matchesSelector,
-  setAutocomplete,
-  getAutocomplete,
   addMember,
   removeMember,
   getMembers,
-  setMembers
+  setMembers,
+  setAutocomplete,
+  getAutocomplete,
+  getMemberMatches
 } from '../MemberSelector/MemberSelector.store'
 
 export function mapStateToProps (state, props) {
-  const people = matchesSelector(state, props)
-  const autocomplete = getAutocomplete(state, props)
-  const members = getMembers(state, props)
   return {
-    people,
-    autocomplete,
-    members
+    members: getMembers(state, props),
+    autocomplete: getAutocomplete(state, props),
+    memberMatches: getMemberMatches(state, props)
   }
 }
 

--- a/src/components/MemberSelector/MemberSelector.connector.js
+++ b/src/components/MemberSelector/MemberSelector.connector.js
@@ -10,7 +10,7 @@ import {
   setAutocomplete,
   getAutocomplete,
   getMemberMatches
-} from '../MemberSelector/MemberSelector.store'
+} from './MemberSelector.store'
 
 export function mapStateToProps (state, props) {
   return {
@@ -28,7 +28,7 @@ export function mapDispatchToProps (dispatch, props) {
       removeMember,
       setMembers
     }, dispatch),
-    fetchPeople: debounce(300, opts => dispatch(fetchPeople(opts)))
+    fetchPeople: debounce(300, (...args) => dispatch(fetchPeople(...args)))
   }
 }
 

--- a/src/components/MemberSelector/MemberSelector.connector.js
+++ b/src/components/MemberSelector/MemberSelector.connector.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux'
-
+import { bindActionCreators } from 'redux'
+import { debounce } from 'lodash/fp'
 import fetchPeople from 'store/actions/fetchPeople'
 import {
   addMember,
@@ -19,8 +20,16 @@ export function mapStateToProps (state, props) {
   }
 }
 
-export const mapDispatchToProps = {
-  fetchPeople, setAutocomplete, addMember, removeMember, setMembers
+export function mapDispatchToProps (dispatch, props) {
+  return {
+    ...bindActionCreators({
+      setAutocomplete,
+      addMember,
+      removeMember,
+      setMembers
+    }, dispatch),
+    fetchPeople: debounce(300, opts => dispatch(fetchPeople(opts)))
+  }
 }
 
 export function mergeProps (stateProps, dispatchProps, ownProps) {

--- a/src/components/MemberSelector/MemberSelector.connector.test.js
+++ b/src/components/MemberSelector/MemberSelector.connector.test.js
@@ -1,4 +1,5 @@
-import { mapStateToProps, mapDispatchToProps } from './EventInviteDialog.connector'
+import { mapStateToProps, mapDispatchToProps } from './MemberSelector.connector'
+import { MODULE_NAME } from './MemberSelector.store'
 
 jest.mock('lodash/fp', () => ({
   ...jest.requireActual('lodash/fp'),
@@ -8,9 +9,14 @@ jest.mock('lodash/fp', () => ({
   }
 }))
 
+jest.mock('./MemberSelector.store', () => ({
+  ...jest.requireActual('./MemberSelector.store'),
+  getMemberMatches: () => jest.fn()
+}))
+
 describe('mapStateToProps', () => {
   it('returns the expected keys', () => {
-    const state = {}
+    const state = { [MODULE_NAME]: {} }
     const props = { forCommunities: [] }
     const stateProps = mapStateToProps(state, props)
     expect(stateProps).toMatchSnapshot()

--- a/src/components/MemberSelector/MemberSelector.js
+++ b/src/components/MemberSelector/MemberSelector.js
@@ -43,13 +43,13 @@ export default class MemberSelector extends Component {
   }
 
   render () {
-    const { placeholder, readOnly, people, autocomplete, members = [] } = this.props
+    const { placeholder, readOnly, memberMatches, autocomplete, members = [] } = this.props
 
     return (
       <TagInput
         placeholder={placeholder}
         tags={members}
-        suggestions={isEmpty(autocomplete) ? [] : people}
+        suggestions={isEmpty(autocomplete) ? [] : memberMatches}
         handleInputChange={this.handleInputChange}
         handleAddition={this.handleAddition}
         handleDelete={this.handleDelete}

--- a/src/components/MemberSelector/MemberSelector.js
+++ b/src/components/MemberSelector/MemberSelector.js
@@ -26,10 +26,11 @@ export default class MemberSelector extends Component {
   }
 
   handleInputChange = input => {
+    const { forCommunities } = this.props
     this.props.setAutocomplete(input)
     if (!isEmpty(input)) {
       // this fetched should be debounced or throttled, maybe here, or in the connector
-      this.props.fetchPeople(input)
+      this.props.fetchPeople(input, forCommunities ? forCommunities.map(c => c.id) : null)
     }
   }
 

--- a/src/components/MemberSelector/MemberSelector.store.js
+++ b/src/components/MemberSelector/MemberSelector.store.js
@@ -3,7 +3,6 @@ import { pick, uniqBy, orderBy, flow, reject, filter, map, reduce } from 'lodash
 
 import getMe from 'store/selectors/getMe'
 import orm from 'store/models'
-import { DROP_QUERY_RESULTS } from 'store/constants'
 
 export const MODULE_NAME = 'MemberSelector'
 
@@ -57,7 +56,7 @@ export const getMemberMatches = createSelector(
     { Community },
     members,
     currentUser,
-    forCommunities = null,
+    forCommunities,
     autocomplete
   ) => {
     const forCommunityIds = forCommunities && forCommunities.map(c => c.id)
@@ -76,9 +75,10 @@ export const getMemberMatches = createSelector(
       map(pick([ 'id', 'name', 'avatarUrl' ])),
       orderBy('name', 'asc')
     ]
-    
+
     return flow(processors)(communities)
-})
+  }
+)
 
 export const defaultState = {
   autocomplete: '',

--- a/src/components/MemberSelector/MemberSelector.test.js
+++ b/src/components/MemberSelector/MemberSelector.test.js
@@ -82,7 +82,7 @@ describe('MemberSelector', () => {
       const theInput = 'hithere'
       wrapper.instance().handleInputChange(theInput)
       expect(setAutocomplete).toHaveBeenCalledWith(theInput)
-      expect(fetchPeople).toHaveBeenCalledWith(theInput)
+      expect(fetchPeople).toHaveBeenCalledWith(theInput, null)
     })
   })
 

--- a/src/components/MemberSelector/__snapshots__/MemberSelector.connector.test.js.snap
+++ b/src/components/MemberSelector/__snapshots__/MemberSelector.connector.test.js.snap
@@ -25,13 +25,18 @@ Object {
 
 exports[`mapDispatchToProps returns the expected keys 1`] = `
 Object {
+  "addMember": [Function],
   "fetchPeople": [Function],
-  "invitePeopleToEvent": [Function],
+  "removeMember": [Function],
+  "setAutocomplete": [Function],
+  "setMembers": [Function],
 }
 `;
 
 exports[`mapStateToProps returns the expected keys 1`] = `
 Object {
-  "people": Array [],
+  "autocomplete": undefined,
+  "memberMatches": [MockFunction],
+  "members": undefined,
 }
 `;

--- a/src/components/PostCard/EventBody/EventBody.js
+++ b/src/components/PostCard/EventBody/EventBody.js
@@ -20,7 +20,7 @@ export default class EventBody extends Component {
   render () {
     const { event, respondToEvent, slug, expanded, className } = this.props
     const { showInviteDialog } = this.state
-    const { id, startTime, endTime, location, eventInvitations } = event
+    const { id, startTime, endTime, location, eventInvitations, communities } = event
 
     return <div styleName={cx('body', 'eventBody', { smallMargin: !expanded })} className={className}>
       <EventDate {...event} />
@@ -41,6 +41,7 @@ export default class EventBody extends Component {
       {showInviteDialog && <EventInviteDialog
         eventId={id}
         eventInvitations={eventInvitations}
+        forCommunities={communities}
         onClose={this.toggleInviteDialog} />}
     </div>
   }

--- a/src/components/PostCard/EventBody/EventBody.js
+++ b/src/components/PostCard/EventBody/EventBody.js
@@ -36,7 +36,7 @@ export default class EventBody extends Component {
       </div>
       <div styleName='eventRightColumn'>
         <EventRSVP {...event} respondToEvent={respondToEvent} />
-        <Button label='Invite' onClick={this.toggleInviteDialog} narrow small color='gray' styleName='inviteButton' />
+        <Button label='Invite' onClick={this.toggleInviteDialog} narrow small color='green-white' styleName='inviteButton' />
       </div>
       {showInviteDialog && <EventInviteDialog
         eventId={id}

--- a/src/components/PostEditor/PostEditor.js
+++ b/src/components/PostEditor/PostEditor.js
@@ -429,6 +429,9 @@ export default class PostEditor extends React.Component {
             <MemberSelector
               initialMembers={members || []}
               onChange={this.updateProjectMembers}
+              // NOTE: Turn-on to limit Project Member selection
+              // to the membership of the selected communities
+              // forCommunities={communities}
               readOnly={loading}
             />
           </div>
@@ -479,8 +482,8 @@ export default class PostEditor extends React.Component {
             <MemberSelector
               initialMembers={eventInvitations || []}
               onChange={this.updateEventInvitations}
-              readOnly={loading}
               forCommunities={communities}
+              readOnly={loading}
             />
           </div>
         </div>}

--- a/src/components/PostEditor/PostEditor.js
+++ b/src/components/PostEditor/PostEditor.js
@@ -480,6 +480,7 @@ export default class PostEditor extends React.Component {
               initialMembers={eventInvitations || []}
               onChange={this.updateEventInvitations}
               readOnly={loading}
+              forCommunities={communities}
             />
           </div>
         </div>}

--- a/src/graphql/queries/PeopleQuery.graphql
+++ b/src/graphql/queries/PeopleQuery.graphql
@@ -1,5 +1,5 @@
-query PeopleQuery ($autocomplete: String, $first: Int) {
-  people (autocomplete: $autocomplete, first: $first) {
+query PeopleQuery ($autocomplete: String, $first: Int, $communityIds: [String]) {
+  people (autocomplete: $autocomplete, first: $first, communityIds: $communityIds) {
     items {
       id
       name

--- a/src/graphql/queries/PeopleQuery.graphql
+++ b/src/graphql/queries/PeopleQuery.graphql
@@ -1,16 +1,35 @@
-query PeopleQuery ($autocomplete: String, $first: Int, $communityIds: [String]) {
-  people (autocomplete: $autocomplete, first: $first, communityIds: $communityIds) {
+query PeopleQuery (
+  $first: Int,
+  $autocomplete: String,
+  $communityIds: [String]
+) {
+  communities(communityIds: $communityIds) {
     items {
       id
-      name
-      avatarUrl
-      memberships {
-        id
-        community {
+      members(first: $first, search: $autocomplete, sortBy: "name", order: "desc") {
+        items {
           id
           name
+          avatarUrl
         }
       }
     }
   }
 }
+
+# query PeopleQuery ($autocomplete: String, $first: Int, $communityIds: [String]) {
+#   people (autocomplete: $autocomplete, first: $first, communityIds: $communityIds) {
+#     items {
+#       id
+#       name
+#       avatarUrl
+#       communityMemberships: memberships {
+#         id
+#         community {
+#           id
+#           name
+#         }
+#       }
+#     }
+#   }
+# }

--- a/src/graphql/queries/PeopleQuery.graphql
+++ b/src/graphql/queries/PeopleQuery.graphql
@@ -16,20 +16,3 @@ query PeopleQuery (
     }
   }
 }
-
-# query PeopleQuery ($autocomplete: String, $first: Int, $communityIds: [String]) {
-#   people (autocomplete: $autocomplete, first: $first, communityIds: $communityIds) {
-#     items {
-#       id
-#       name
-#       avatarUrl
-#       communityMemberships: memberships {
-#         id
-#         community {
-#           id
-#           name
-#         }
-#       }
-#     }
-#   }
-# }

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import createStore from './store'
 import './client/websockets'
 import { rootDomId } from 'client/util'
 
-// Apollo Setup for possible use with Hylo-node backend 
+// Apollo Setup for possible use with Hylo-node backend
 //
 // import { ApolloProvider } from 'react-apollo'
 // import apolloClient from 'client/apolloClient'

--- a/src/store/actions/__snapshots__/fetchPeople.test.js.snap
+++ b/src/store/actions/__snapshots__/fetchPeople.test.js.snap
@@ -6,11 +6,15 @@ Object {
     "query": "All the lonely people / Where do they all come from?",
     "variables": Object {
       "autocomplete": "Tchaikovs",
+      "communityIds": Array [],
       "first": 100,
     },
   },
   "meta": Object {
-    "extractModel": "Person",
+    "extractModel": "Community",
+    "extractQueryResults": Object {
+      "getItems": [Function],
+    },
   },
   "type": "FETCH_PEOPLE",
 }

--- a/src/store/actions/fetchPeople.js
+++ b/src/store/actions/fetchPeople.js
@@ -1,7 +1,8 @@
+import { get } from 'lodash/fp'
 import { FETCH_PEOPLE } from 'store/constants'
 import PeopleQuery from 'graphql/queries/PeopleQuery.graphql'
 
-export default function fetchPeople (autocomplete, communityIds, query = PeopleQuery, first = 20) {
+export default function fetchPeople (autocomplete, communityIds = null, query = PeopleQuery, first = 20) {
   return {
     type: FETCH_PEOPLE,
     graphql: {
@@ -9,7 +10,10 @@ export default function fetchPeople (autocomplete, communityIds, query = PeopleQ
       variables: { autocomplete, first, communityIds }
     },
     meta: {
-      extractModel: 'Person'
+      extractModel: 'Community',
+      extractQueryResults: {
+        getItems: get('payload.data.community.members')
+      }
     }
   }
 }

--- a/src/store/actions/fetchPeople.js
+++ b/src/store/actions/fetchPeople.js
@@ -2,7 +2,7 @@ import { get } from 'lodash/fp'
 import { FETCH_PEOPLE } from 'store/constants'
 import PeopleQuery from 'graphql/queries/PeopleQuery.graphql'
 
-export default function fetchPeople (autocomplete, communityIds = null, query = PeopleQuery, first = 20) {
+export default function fetchPeople (autocomplete, communityIds, query = PeopleQuery, first = 20) {
   return {
     type: FETCH_PEOPLE,
     graphql: {

--- a/src/store/actions/fetchPeople.js
+++ b/src/store/actions/fetchPeople.js
@@ -1,12 +1,12 @@
 import { FETCH_PEOPLE } from 'store/constants'
 import PeopleQuery from 'graphql/queries/PeopleQuery.graphql'
 
-export default function fetchPeople (autocomplete, query = PeopleQuery, first = 20) {
+export default function fetchPeople (autocomplete, communityIds, query = PeopleQuery, first = 20) {
   return {
     type: FETCH_PEOPLE,
     graphql: {
       query,
-      variables: { autocomplete, first }
+      variables: { autocomplete, first, communityIds }
     },
     meta: {
       extractModel: 'Person'

--- a/src/store/actions/fetchPeople.test.js
+++ b/src/store/actions/fetchPeople.test.js
@@ -9,6 +9,6 @@ it('matches the last snapshot', () => {
     }
   }
   const { query, variables } = graphql
-  const actual = fetchPeople(variables.autocomplete, query, variables.first)
+  const actual = fetchPeople(variables.autocomplete, [], query, variables.first)
   expect(actual).toMatchSnapshot()
 })


### PR DESCRIPTION
Requires: https://github.com/Hylozoic/hylo-node/pull/500

In addition to things mention in attached tickets this update includes addition of debounce for invitee search in both edit and add contexts, better visibility of "Invite" link in Post Card view, some refactoring, and somewhat more testing. 

IMPORTANT: Until we're done QA'ing this I've left the feature flag in place. So to release this to production we need to set the following ENV variable: `FEATURE_FLAG_EVENTS=on`

\* NOTE: The notifications story related to inviting has not been carefully QA'd.