### PR TITLE
remove tagline from constrained posts

### DIFF
--- a/src/components/PostCard/PostHeader/PostHeader.js
+++ b/src/components/PostCard/PostHeader/PostHeader.js
@@ -106,9 +106,9 @@ export default class PostHeader extends PureComponent {
         <Avatar avatarUrl={creator.avatarUrl} url={creatorUrl} styleName='avatar' />
         <div styleName='headerText'>
           <Highlight {...highlightProps}>
-            <Link to={creatorUrl} styleName='userName'>{creator.name}{creator.tagline && ', '}</Link>
+            <Link to={creatorUrl} styleName='userName'>{creator.name}{creator.tagline && !constrained && ', '}</Link>
           </Highlight>
-          {creator.tagline && <span styleName='userTitle'>{creator.tagline}</span>}
+          {creator.tagline && !constrained ? <span styleName='userTitle'>{creator.tagline}</span> : ''}
           <div styleName='timestampRow'>
             <span styleName='timestamp'>
               {humanDate(createdAt)}

--- a/src/routes/Signup/UploadPhoto/UploadPhoto.js
+++ b/src/routes/Signup/UploadPhoto/UploadPhoto.js
@@ -38,7 +38,7 @@ export default class UploadPhoto extends Component {
 
   render () {
     const { currentUser, uploadImagePending } = this.props
-    
+
     if (!currentUser) return <Loading />
 
     const currentAvatarUrl = this.getValue('avatarUrl')


### PR DESCRIPTION
Hides member's tagline on constrained posts in map drawer, so tagline doesn't overflow other content