### PR TITLE
Stay in current context when viewing a project from a profile

### DIFF
--- a/src/graphql/queries/personQuery.js
+++ b/src/graphql/queries/personQuery.js
@@ -57,6 +57,9 @@ export default
             avatarUrl
           }
         }
+        communities {
+          slug
+        }
       }
     }
     skills (first: 100) {

--- a/src/routes/MemberProfile/MemberProfile.connector.js
+++ b/src/routes/MemberProfile/MemberProfile.connector.js
@@ -41,14 +41,12 @@ export function mapStateToProps (state, props) {
   }
 }
 
-export function mapDispatchToProps (dispatch, props) {
-  const { routeParams, querystringParams } = props
-
+export function mapDispatchToProps (dispatch) {
   return {
     fetchPerson: (id) => dispatch(fetchPerson(id)),
     blockUser: (id) => dispatch(blockUser(id)),
     push,
-    showDetails: (id) => dispatch(push(postUrl(id, routeParams, querystringParams)))
+    showDetails: (id, routeParams) => dispatch(push(postUrl(id, routeParams)))
   }
 }
 

--- a/src/routes/MemberProfile/MemberProfile.js
+++ b/src/routes/MemberProfile/MemberProfile.js
@@ -127,7 +127,7 @@ export default class MemberProfile extends React.Component {
           <div styleName='profile-subhead'>
             Projects
           </div>
-          {projects && projects.length > 0 && projects.map((p, index) => <Project key={index} memberCap={3} project={p} showDetails={showDetails} />)}
+          {projects && projects.length > 0 && projects.map((p, index) => <Project key={index} memberCap={3} project={p} routeParams={routeParams} showDetails={showDetails} />)}
         </div>
       </div>
       <div styleName='content'>
@@ -226,10 +226,11 @@ export function ActionDropdown ({ items }) {
     />
 }
 
-export function Project ({ memberCap, project, showDetails }) {
-  const { title, id, createdAt, creator, members } = project
+export function Project ({ memberCap, project, routeParams, showDetails }) {
+  const { title, id, communities, createdAt, creator, members } = project
+  const postTypeContext = communities.map(c => c.slug).includes(routeParams.slug) ? 'project' : undefined
   return (
-    <div styleName='project' onClick={() => showDetails(id)}>
+    <div styleName='project' onClick={() => showDetails(id, { ...routeParams, postTypeContext })}>
       <div>
         <div styleName='title'>{title} </div>
         <div styleName='meta'>{creator.name} - {Moment(createdAt).fromNow()} </div>


### PR DESCRIPTION
Addresses #703 

This change makes it so the user stays in the current context, which I think is preferable for now. @lorenjohnson I think you were saying that the navigation was designed to stick with the current context, which is what I'm seeing here. 

The change to default to all communities instead of the current one if the project/post does not exist in the current context would involve [this navigation util function `baseUrl`](https://github.com/Hylozoic/hylo-evo/blob/dev/src/util/navigation.js#L60-L92).  It has to do with how the `communityUrl` is prioritized before the `defaultUrl`. `baseUrl` is used in a bunch of places though so it feels like a bigger conversation to have around what we want the UX around context to be. 