### PR TITLE
476 fix creating empty comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ - Doesn't allow posting of an empty comment.
 
 ## [2.2.3] - 2020-12-16
 ### Fixed

--- a/src/components/HyloEditor/HyloEditor.js
+++ b/src/components/HyloEditor/HyloEditor.js
@@ -122,7 +122,7 @@ export default class HyloEditor extends Component {
     const contentStateChanged =
       this.state.editorState.getCurrentContent() !== editorState.getCurrentContent()
     if (this.props.onChange) this.props.onChange(editorState, contentStateChanged)
-    this.setState({ editorState, error: null })
+    this.setState({ editorState })
   }
 
   handleMentionsSearch = ({ value }) => {
@@ -209,7 +209,6 @@ export default class HyloEditor extends Component {
         suggestions={topicSuggestions}
         onOpen={this.disableSubmitOnReturn}
         onClose={this.handleTopicsClose} />
-      { this.state.error && <span styleName='error'>{this.state.error}</span>}
     </div>
   }
 }

--- a/src/components/HyloEditor/HyloEditor.js
+++ b/src/components/HyloEditor/HyloEditor.js
@@ -122,7 +122,7 @@ export default class HyloEditor extends Component {
     const contentStateChanged =
       this.state.editorState.getCurrentContent() !== editorState.getCurrentContent()
     if (this.props.onChange) this.props.onChange(editorState, contentStateChanged)
-    this.setState({ editorState })
+    this.setState({ editorState, error: null })
   }
 
   handleMentionsSearch = ({ value }) => {
@@ -140,6 +140,9 @@ export default class HyloEditor extends Component {
     const { submitOnReturnHandler } = this.props
     if (submitOnReturnHandler && this.state.submitOnReturnEnabled) {
       if (this.isEmpty()) {
+        this.setState({
+          error: "Comment can't be empty. Please enter a non-empty comment."
+        })
         return 'handled'
       }
       if (!event.shiftKey) {
@@ -211,6 +214,7 @@ export default class HyloEditor extends Component {
         suggestions={topicSuggestions}
         onOpen={this.disableSubmitOnReturn}
         onClose={this.handleTopicsClose} />
+      { this.state.error && <span styleName='error'>{this.state.error}</span>}
     </div>
   }
 }

--- a/src/components/HyloEditor/HyloEditor.js
+++ b/src/components/HyloEditor/HyloEditor.js
@@ -138,15 +138,10 @@ export default class HyloEditor extends Component {
 
   handleReturn = (event) => {
     const { submitOnReturnHandler } = this.props
+    const { editorState } = this.state
     if (submitOnReturnHandler && this.state.submitOnReturnEnabled) {
-      if (this.isEmpty()) {
-        this.setState({
-          error: "Comment can't be empty. Please enter a non-empty comment."
-        })
-        return 'handled'
-      }
       if (!event.shiftKey) {
-        submitOnReturnHandler(this.getContentHTML())
+        submitOnReturnHandler(editorState)
         this.setState({
           editorState: EditorState.moveFocusToEnd(EditorState.createEmpty())
         })

--- a/src/components/HyloEditor/HyloEditor.js
+++ b/src/components/HyloEditor/HyloEditor.js
@@ -139,6 +139,9 @@ export default class HyloEditor extends Component {
   handleReturn = (event) => {
     const { submitOnReturnHandler } = this.props
     if (submitOnReturnHandler && this.state.submitOnReturnEnabled) {
+      if (this.isEmpty()) {
+        return 'handled'
+      }
       if (!event.shiftKey) {
         submitOnReturnHandler(this.getContentHTML())
         this.setState({

--- a/src/components/HyloEditor/HyloEditor.scss
+++ b/src/components/HyloEditor/HyloEditor.scss
@@ -18,8 +18,3 @@
   color: $color-rhino-80;
   cursor: default;
 }
-
-.error {
-  color: $color-amaranth;
-  font-size: 12px;
-}

--- a/src/components/HyloEditor/HyloEditor.scss
+++ b/src/components/HyloEditor/HyloEditor.scss
@@ -18,3 +18,8 @@
   color: $color-rhino-80;
   cursor: default;
 }
+
+.error {
+  color: $color-amaranth;
+  font-size: 12px;
+}

--- a/src/routes/PostDetail/Comments/Comment/Comment.js
+++ b/src/routes/PostDetail/Comments/Comment/Comment.js
@@ -35,7 +35,8 @@ export default class Comment extends Component {
 
   saveComment = editorState => {
     const { comment } = this.props
-    if (!editorState.getCurrentContent().hasText() && isEmpty(comment.attachments)) {
+    const contentState = editorState.getCurrentContent()
+    if ((!contentState.hasText() || isEmpty(contentState.getPlainText().trim())) && isEmpty(comment.attachments)) {
       // Don't accept empty comments.
       return
     }

--- a/src/routes/PostDetail/Comments/Comment/Comment.js
+++ b/src/routes/PostDetail/Comments/Comment/Comment.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
-import { filter, isFunction } from 'lodash/fp'
+import { filter, isEmpty, isFunction } from 'lodash/fp'
 import { humanDate, present, sanitize } from 'hylo-utils/text'
 import { personUrl } from 'util/navigation'
 import Avatar from 'components/Avatar'
@@ -34,6 +34,12 @@ export default class Comment extends Component {
   }
 
   saveComment = editorState => {
+    const { comment } = this.props
+    if (!editorState.getCurrentContent().hasText() && isEmpty(comment.attachments)) {
+      // Don't accept empty comments.
+      return
+    }
+
     this.setState({ editing: false })
     this.props.updateComment(contentStateToHTML(editorState.getCurrentContent()))
   }

--- a/src/routes/PostDetail/Comments/Comment/Comment.js
+++ b/src/routes/PostDetail/Comments/Comment/Comment.js
@@ -9,6 +9,7 @@ import Dropdown from 'components/Dropdown'
 import Icon from 'components/Icon'
 import ClickCatcher from 'components/ClickCatcher'
 import HyloEditor from 'components/HyloEditor'
+import contentStateToHTML from 'components/HyloEditor/contentStateToHTML'
 import CardImageAttachments from 'components/CardImageAttachments'
 import CardFileAttachments from 'components/CardFileAttachments'
 import './Comment.scss'
@@ -32,9 +33,9 @@ export default class Comment extends Component {
     this.setState({ editing: true })
   }
 
-  saveComment = text => {
+  saveComment = editorState => {
     this.setState({ editing: false })
-    this.props.updateComment(text)
+    this.props.updateComment(contentStateToHTML(editorState.getCurrentContent()))
   }
 
   render () {

--- a/src/routes/PostDetail/Comments/CommentForm/CommentForm.js
+++ b/src/routes/PostDetail/Comments/CommentForm/CommentForm.js
@@ -43,8 +43,8 @@ export default class CommentForm extends Component {
       attachments,
       clearAttachments
     } = this.props
-
-    if (!editorState.getCurrentContent().hasText() && isEmpty(attachments)) {
+    const contentState = editorState.getCurrentContent()
+    if ((!contentState.hasText() || isEmpty(contentState.getPlainText().trim())) && isEmpty(attachments)) {
       // Don't accept empty comments.
       return
     }

--- a/src/routes/PostDetail/Comments/CommentForm/CommentForm.js
+++ b/src/routes/PostDetail/Comments/CommentForm/CommentForm.js
@@ -1,10 +1,11 @@
 import cx from 'classnames'
-import { throttle } from 'lodash'
+import { throttle, isEmpty } from 'lodash/fp'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import AttachmentManager from 'components/AttachmentManager'
 import HyloEditor from 'components/HyloEditor'
+import contentStateToHTML from 'components/HyloEditor/contentStateToHTML'
 import Icon from 'components/Icon'
 import Loading from 'components/Loading'
 import RoundImage from 'components/RoundImage'
@@ -29,19 +30,25 @@ export default class CommentForm extends Component {
 
   editor = React.createRef()
 
-  startTyping = throttle((editorState, stateChanged) => {
+  startTyping = throttle(STARTED_TYPING_INTERVAL, (editorState, stateChanged) => {
     if (editorState.getLastChangeType() === 'insert-characters' && stateChanged) {
       this.props.sendIsTyping(true)
     }
-  }, STARTED_TYPING_INTERVAL)
+  })
 
-  save = text => {
+  save = editorState => {
     const {
       createComment,
       sendIsTyping,
       attachments,
       clearAttachments
     } = this.props
+
+    if (!editorState.getCurrentContent().hasText() && isEmpty(attachments)) {
+      // Don't accept empty comments.
+      return
+    }
+    const text = contentStateToHTML(editorState.getCurrentContent())
 
     this.startTyping.cancel()
     sendIsTyping(false)


### PR DESCRIPTION
Related to #476 

Adds a simple check if the content of the comment is empty. Displays an inline error if an empty comment is tried to be posted.
:warning: Please let me know if the error message is alright. Dunno how user friendly it is.

---

:rotating_light: This solution doesn't permit posting a comment with only an attachment. Attaching an attachment and pressing _enter_ triggers the empty comment error. This is because the attachment is at one level higher - in the [`CommentForm`](https://github.com/Hylozoic/hylo-evo/blob/15adf47506fa9604d5ef190678980aef2244f3d5/src/routes/PostDetail/Comments/CommentForm/CommentForm.js#L38-L53), while the fix is introduced in the `HyloEditor`.

**Q:** Why not introduce the fix in the `CommentsFrom#save`?
**A:** In the `save` we have the html content, an empty content is in the form of `<p></p>`. Hardcoding an empty check against `<p></p>` looks like a bad idea to me.(I have no good argument here, let me know if this approach should be pursued).

Let me know if this is a showstopper. Thanks for the opportunity!