### PR TITLE
Made it so you can type in topics with hashtags. Small bug(?) introdu…

### DIFF
--- a/src/components/TopicSelector/TopicSelector.js
+++ b/src/components/TopicSelector/TopicSelector.js
@@ -78,6 +78,9 @@ export default class TopicSelector extends Component {
   }
 
   handleInputChange = async (input) => {
+    if (input.charAt(0) === '#') {
+      input = input.slice(1)
+    }
     this.setState({ input })
     if (!isEmpty(input)) {
       if (this.state.selected.length >= MAX_TOPICS) {
@@ -109,6 +112,7 @@ export default class TopicSelector extends Component {
     const { currentGroup, defaultTopics, placeholder } = this.props
     const { selected } = this.state
 
+    let sanitizedValue = ''
     // If at max # topics don't show more default topics to select
     const defaultsToShow = selected.length >= MAX_TOPICS ? [] : defaultTopics ? [ { label: currentGroup ? currentGroup.name : 'Default' + ' Topics', options: defaultTopics } ] : []
 
@@ -123,18 +127,30 @@ export default class TopicSelector extends Component {
         styles={inputStyles}
         loadOptions={this.handleInputChange}
         onChange={this.handleTopicsChange}
-        getNewOptionData={(inputValue, optionLabel) => (selected.length >= MAX_TOPICS ? null : { name: inputValue, label: inputValue, value: inputValue, __isNew__: true })}
-        noOptionsMessage={() => {
-          return selected.length >= MAX_TOPICS ? 'You can only select up to 3 topics' : 'Start typing to add a topic'
+        getNewOptionData={(inputValue, optionLabel) => (
+          sanitizedValue = inputValue.charAt(0) === '#' ? inputValue.slice(1) : inputValue,
+          selected.length >= MAX_TOPICS ? null : {
+            name: sanitizedValue,
+            label: sanitizedValue,
+            value: sanitizedValue,
+            __isNew__: true }
+        )}
+        noOptionsMessage={(inputValue) => {
+          return selected.length >= MAX_TOPICS  ? 'You can only select up to 3 topics' : 'Start typing to add a topic'
         }}
         formatOptionLabel={(item, { context, inputValue, selectValue }) => {
+          console.log(item)
+          if (item.label === "") {
+            return <span>Start typing to add a topic</span>
+          }
           if (context === 'value') {
             return <div styleName='topicLabel'>#{item.label}</div>
           }
           if (item.__isNew__) {
-            return <div>Create topic &quot;{item.value}&quot;</div>
+            return <div>Create topic &quot;#{item.value}&quot;</div>
           }
           const { name, postsTotal, followersTotal } = item
+
           const formatCount = count => isNaN(count)
             ? 0
             : count < 1000

--- a/src/components/TopicSelector/TopicSelector.js
+++ b/src/components/TopicSelector/TopicSelector.js
@@ -112,7 +112,6 @@ export default class TopicSelector extends Component {
     const { currentGroup, defaultTopics, placeholder } = this.props
     const { selected } = this.state
 
-    let sanitizedValue = ''
     // If at max # topics don't show more default topics to select
     const defaultsToShow = selected.length >= MAX_TOPICS ? [] : defaultTopics ? [ { label: currentGroup ? currentGroup.name : 'Default' + ' Topics', options: defaultTopics } ] : []
 
@@ -127,20 +126,19 @@ export default class TopicSelector extends Component {
         styles={inputStyles}
         loadOptions={this.handleInputChange}
         onChange={this.handleTopicsChange}
-        getNewOptionData={(inputValue, optionLabel) => (
-          sanitizedValue = inputValue.charAt(0) === '#' ? inputValue.slice(1) : inputValue,
-          selected.length >= MAX_TOPICS ? null : {
+        getNewOptionData={(inputValue, optionLabel) => {
+          const sanitizedValue = inputValue.charAt(0) === '#' ? inputValue.slice(1) : inputValue
+          return selected.length >= MAX_TOPICS ? null : {
             name: sanitizedValue,
             label: sanitizedValue,
             value: sanitizedValue,
             __isNew__: true }
-        )}
+        }}
         noOptionsMessage={(inputValue) => {
-          return selected.length >= MAX_TOPICS  ? 'You can only select up to 3 topics' : 'Start typing to add a topic'
+          return selected.length >= MAX_TOPICS ? 'You can only select up to 3 topics' : 'Start typing to add a topic'
         }}
         formatOptionLabel={(item, { context, inputValue, selectValue }) => {
-          console.log(item)
-          if (item.label === "") {
+          if (item.label === '') {
             return <span>Start typing to add a topic</span>
           }
           if (context === 'value') {


### PR DESCRIPTION
…ced... when entering a hashtag, if the only thing entered is the octothorpe, the status message still says "Start by adding a topic" but it is now a selectable item in the list. Pressing return cancels the input.

What's happening is that AsyncCreatableSelect thinks there's an input (which there is, even though we take out the octothorpe) and so it's calling formatOptionLabel on line 141.

The behavior should, at some point, shift to the default behavior of noOptionsMessage on line 138. To do this, I think we have to capture the input before it goes to AsyncCreatableSelect, not quite sure how to do this.

As it stands, this behavior is much better than current behavior and the "bug" is not all that bad.