### PR TITLE
Hylo.com links target _self

### DIFF
--- a/src/components/ClickCatcher/ClickCatcher.js
+++ b/src/components/ClickCatcher/ClickCatcher.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { hyloUrlRegex } from 'util/navigation'
+import { HYLO_URL_REGEX } from 'util/navigation'
 
 export default function ClickCatcher ({ tag, handleMouseOver, navigate, ...props }) {
   if (!['div', 'span', 'p'].includes(tag)) {
@@ -21,7 +21,7 @@ export default function ClickCatcher ({ tag, handleMouseOver, navigate, ...props
       node.setAttribute('target', '_blank')
     }
 
-    const matches = [...node.getAttribute('href').matchAll(hyloUrlRegex)]
+    const matches = [...node.getAttribute('href').matchAll(HYLO_URL_REGEX)]
     if (matches[0] && matches[0].length === 2) {
       node.setAttribute('target', '_self')
       const urlPath = matches[0][1] === '' ? '/' : matches[0][1]

--- a/src/components/ClickCatcher/ClickCatcher.js
+++ b/src/components/ClickCatcher/ClickCatcher.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { hyloUrlRegex } from 'util/navigation'
 
 export default function ClickCatcher ({ tag, handleMouseOver, navigate, ...props }) {
   if (!['div', 'span', 'p'].includes(tag)) {
@@ -18,6 +19,13 @@ export default function ClickCatcher ({ tag, handleMouseOver, navigate, ...props
 
     if (node.getAttribute('target') !== '_blank') {
       node.setAttribute('target', '_blank')
+    }
+
+    const matches = [...node.getAttribute('href').matchAll(hyloUrlRegex)]
+    if (matches[0] && matches[0].length === 2) {
+      node.setAttribute('target', '_self')
+      const urlPath = matches[0][1] === '' ? '/' : matches[0][1]
+      node.setAttribute('href', urlPath)
     }
   }
   return React.createElement(tag, { ...props, onClick: handleClick })

--- a/src/util/navigation.js
+++ b/src/util/navigation.js
@@ -13,7 +13,7 @@ export const REQUIRED_EDIT_POST_MATCH = `:detail(post)/:postId(${POST_ID_MATCH})
 
 export const GROUP_DETAIL_MATCH = `:detail(group)/:detailGroupSlug`
 export const OPTIONAL_GROUP_MATCH = `:detail(group)?/(:detailGroupSlug)?`
-export const hyloUrlRegex = /http[s]?:\/\/hylo\.com(.*)/g // https://regex101.com/r/yQxli1/1/
+export const HYLO_URL_REGEX = /http[s]?:\/\/hylo\.com(.*)/g // https://regex101.com/r/yQxli1/1/
 
 // Fundamental URL paths
 

--- a/src/util/navigation.js
+++ b/src/util/navigation.js
@@ -13,6 +13,7 @@ export const REQUIRED_EDIT_POST_MATCH = `:detail(post)/:postId(${POST_ID_MATCH})
 
 export const GROUP_DETAIL_MATCH = `:detail(group)/:detailGroupSlug`
 export const OPTIONAL_GROUP_MATCH = `:detail(group)?/(:detailGroupSlug)?`
+export const hyloUrlRegex = /http[s]?:\/\/hylo\.com(.*)/g // https://regex101.com/r/yQxli1/1/
 
 // Fundamental URL paths
 


### PR DESCRIPTION
Closes #922 

@lorenjohnson , turns out there was already a `clickCatcher` munging links on the components anyway...

I put the hylo.com regex in the navigation folder. It should capture any hylo with http or https, but not email addresses or `something.hylo.com`. Included a link to the regex101 for testing purposes.