### PR TITLE
Fix social signup, minimal change-set, closes #930

### DIFF
--- a/src/routes/NonAuthLayout/Signup/Signup.connector.js
+++ b/src/routes/NonAuthLayout/Signup/Signup.connector.js
@@ -1,20 +1,25 @@
 import { connect } from 'react-redux'
+import { push } from 'connected-react-router'
 import getLoginError from 'store/selectors/getLoginError'
 import { getReturnToURL, resetReturnToURL } from 'router/AuthRoute/AuthRoute.store'
 import mobileRedirect from 'util/mobileRedirect'
+import getQuerystringParam from 'store/selectors/getQuerystringParam'
 import { signup } from './Signup.store'
+import { loginWithService } from '../Login/Login.store'
 
-export function mapStateToProps (state) {
+export function mapStateToProps (state, props) {
   return {
     error: getLoginError(state),
-    returnToURL: getReturnToURL(state),
+    returnToURL: getQuerystringParam('returnToUrl', state, props) || getReturnToURL(state),
     downloadAppUrl: mobileRedirect()
   }
 }
 
 export const mapDispatchToProps = {
   signup,
-  resetReturnToURL
+  resetReturnToURL,
+  loginWithService,
+  push
 }
 
 export function mergeProps (stateProps, dispatchProps, ownProps) {

--- a/src/routes/NonAuthLayout/Signup/Signup.connector.test.js
+++ b/src/routes/NonAuthLayout/Signup/Signup.connector.test.js
@@ -5,7 +5,7 @@ describe('Signup', () => {
     expect(mapDispatchToProps.signup('name', 'test@hylo.com', 'testPassword')).toMatchSnapshot()
   })
   it('returns the right keys', () => {
-    expect(mapStateToProps({}, {}).hasOwnProperty('downloadAppUrl')).toBeTruthy()
-    expect(mapStateToProps({}, {}).hasOwnProperty('returnToURL')).toBeTruthy()
+    expect(mapStateToProps({}, { location: { search: '' } }).hasOwnProperty('downloadAppUrl')).toBeTruthy()
+    expect(mapStateToProps({}, { location: { search: '' } }).hasOwnProperty('returnToURL')).toBeTruthy()
   })
 })

--- a/src/routes/NonAuthLayout/Signup/Signup.js
+++ b/src/routes/NonAuthLayout/Signup/Signup.js
@@ -31,6 +31,11 @@ export default class Signup extends React.Component {
     })
   }
 
+  signupAndRedirect = (service) => {
+    this.props.loginWithService(service)
+      .then(({ error }) => error || this.props.redirectOnSignIn('/'))
+  }
+
   disableField = (e) => {
     this.setState({
       [`${e.target.name}Active`]: false
@@ -99,9 +104,10 @@ export default class Signup extends React.Component {
         </div>
         <Button styleName='submit' label='Sign Up' onClick={this.submit} />
       </div>
+      <div> Or </div>
       <div styleName='auth-buttons'>
-        <FacebookButton signUp onClick={this.submit} />
-        <GoogleButton signUp onClick={this.submit} />
+        <FacebookButton onClick={() => this.signupAndRedirect('facebook')} />
+        <GoogleButton onClick={() => this.signupAndRedirect('google')} />
       </div>
     </div>
   }

--- a/src/routes/NonAuthLayout/Signup/__snapshots__/Signup.test.js.snap
+++ b/src/routes/NonAuthLayout/Signup/__snapshots__/Signup.test.js.snap
@@ -91,16 +91,17 @@ exports[`Signup renders correctly 1`] = `
       onClick={[Function]}
     />
   </div>
+  <div>
+     Or 
+  </div>
   <div
     data-stylename="auth-buttons"
   >
     <FacebookButton
       onClick={[Function]}
-      signUp={true}
     />
     <FacebookButton
       onClick={[Function]}
-      signUp={true}
     />
   </div>
 </div>
@@ -200,16 +201,17 @@ exports[`Signup renders correctly with mobile redirect 1`] = `
       onClick={[Function]}
     />
   </div>
+  <div>
+     Or 
+  </div>
   <div
     data-stylename="auth-buttons"
   >
     <FacebookButton
       onClick={[Function]}
-      signUp={true}
     />
     <FacebookButton
       onClick={[Function]}
-      signUp={true}
     />
   </div>
 </div>


### PR DESCRIPTION
Closes #930 

Ok, stripped it down to the bare minimum changes. Tried replicating the code in login.connector to signup.connector but there is some unaccounted for side-effect that throws an error when one uses the 'signup' action type instead of the 'login' action type.

Backed out of the React 17 update for now. App seemed to work fine but many tests broke. Most of the React 17 changes are 'behind the scenes', so it makes sense to me that the testing libraries would need to be updated for it to work.

Verified with both Facebook and Google signups