### PR TITLE
1025 incorrectly showing posts as ended

### DIFF
--- a/src/components/CommentCard/CommentCard.connector.js
+++ b/src/components/CommentCard/CommentCard.connector.js
@@ -3,9 +3,7 @@ import { push } from 'connected-react-router'
 import { postUrl } from 'util/navigation'
 
 export function mapStateToProps (state, props) {
-  return {
-    routeParams: props.routeParams || {}
-  }
+  return { }
 }
 
 export function mapDispatchToProps (dispatch, props) {

--- a/src/components/PostCard/PostBody/PostBody.scss
+++ b/src/components/PostCard/PostBody/PostBody.scss
@@ -158,7 +158,7 @@
   }
 
   .calendarDate {
-    margin-top: -40px;
+    margin-top: -20px;
 
     > div {
       background-color: rgba(255, 255, 255, 1);

--- a/src/components/PostCard/PostHeader/PostHeader.js
+++ b/src/components/PostCard/PostHeader/PostHeader.js
@@ -72,17 +72,27 @@ export default class PostHeader extends PureComponent {
     const typesWithTimes = ['offer', 'request', 'resource', 'project']
     const canHaveTimes = typesWithTimes.includes(type)
 
-    const { from, to } = formatDatePair(startTime, endTime, true)
-    const startDate = isDateInTheFuture(startTime) ? from : ''
-    const endDate = endTime !== moment() && isDateInTheFuture(endTime) ? `ends ${to}` : `ended ${to}`
+    // If it was completed/fulfilled before it ended, then use that as the end datetime
+    let actualEndTime = fulfilledAt && fulfilledAt < endTime ? fulfilledAt : endTime
+
+    const { from, to } = formatDatePair(startTime, actualEndTime, true)
+    const startString = isDateInTheFuture(startTime) ? `Starts: ${from}` : false
+
+    let endString = false
+    if (fulfilledAt && fulfilledAt <= endTime) {
+      endString = `Completed: ${to}`
+    } else {
+      endString = endTime !== moment() && isDateInTheFuture(endTime) ? `Ends: ${to}` : actualEndTime ? `Ended: ${to}` : false
+    }
+
     let timeWindow = ''
 
-    if (startDate && endDate) {
-      timeWindow = `${type} starts ${startDate} and ${endDate}`
-    } else if (endDate) {
-      timeWindow = `${type} ${endDate}`
-    } else if (startDate) {
-      timeWindow = `${type} starts ${startDate}`
+    if (startString && endString) {
+      timeWindow = `${startString} / ${endString}`
+    } else if (endString) {
+      timeWindow = endString
+    } else if (startString) {
+      timeWindow = startString
     }
 
     return <div styleName={cx('header', { constrained })} className={className}>

--- a/src/components/PostCard/PostHeader/PostHeader.scss
+++ b/src/components/PostCard/PostHeader/PostHeader.scss
@@ -1,6 +1,6 @@
 .header {
   padding: 0px 15px;
-  margin-bottom: 30px;
+  margin-bottom: 10px;
 }
 
 .headerMainRow {
@@ -73,7 +73,7 @@
   margin: 0 7px;
   font-size: 8px;
   position: relative;
-  top: -1px;
+  top: -6px;
 }
 
 .timestampRow {
@@ -89,7 +89,6 @@
 .timeWindow {
   color: $color-caribbean-green;
   opacity: 0.75;
-  text-transform: uppercase;
   font-size: 12px;
   font-weight: bold;
   margin: 10px;

--- a/src/components/PostCard/PostHeader/PostHeader.test.js
+++ b/src/components/PostCard/PostHeader/PostHeader.test.js
@@ -76,17 +76,17 @@ it('renders human readable dates', () => {
     label: 'some context',
     url: '/foo/bar'
   }
-  let startTime = '11/29/2020'
-  let endTime = '11/29/2029'
+  let startTime = '2020-11-29'
+  let endTime = '2029-11-29'
 
   const wrapper = shallow(<PostHeader type='request' groups={groups} creator={creator} context={context} startTime={startTime} endTime={endTime} />)
   expect(wrapper).toMatchSnapshot()
-  startTime = '11/29/2022'
-  endTime = '11/29/2029'
+  startTime = '2022-11-29'
+  endTime = '2029-11-29'
   wrapper.setProps({ startTime, endTime })
   expect(wrapper).toMatchSnapshot()
-  startTime = '11/29/2010'
-  endTime = '11/29/2020'
+  startTime = '2010-11-29'
+  endTime = '2020-11-29'
   wrapper.setProps({ startTime, endTime })
   expect(wrapper).toMatchSnapshot()
 })

--- a/src/components/PostCard/PostHeader/__snapshots__/PostHeader.test.js.snap
+++ b/src/components/PostCard/PostHeader/__snapshots__/PostHeader.test.js.snap
@@ -163,9 +163,7 @@ exports[`matches announcement snapshot 2`] = `
   </div>
   <div
     data-stylename="timeWindow"
-  >
-    request ended 
-  </div>
+  />
 </div>
 `;
 
@@ -264,9 +262,7 @@ exports[`matches announcement snapshot 3`] = `
   </div>
   <div
     data-stylename="timeWindow"
-  >
-    request ended 
-  </div>
+  />
 </div>
 `;
 
@@ -356,9 +352,7 @@ exports[`matches snapshot 2`] = `
   </div>
   <div
     data-stylename="timeWindow"
-  >
-    request ended 
-  </div>
+  />
 </div>
 `;
 
@@ -430,9 +424,7 @@ exports[`matches snapshot 3`] = `
   </div>
   <div
     data-stylename="timeWindow"
-  >
-    request ended 
-  </div>
+  />
 </div>
 `;
 
@@ -482,7 +474,7 @@ exports[`renders human readable dates 1`] = `
   <div
     data-stylename="timeWindow"
   >
-    request ends Thu, Nov 29, 2029 at 12:00AM GMT
+    Ends: Thu, Nov 29, 2029 at 12:00AM GMT
   </div>
 </div>
 `;
@@ -533,7 +525,7 @@ exports[`renders human readable dates 2`] = `
   <div
     data-stylename="timeWindow"
   >
-    request starts Tue, Nov 29, 2022 at 12:00AM and ends Thu, Nov 29, 2029 at 12:00AM GMT
+    Starts: Tue, Nov 29, 2022 at 12:00AM / Ends: Thu, Nov 29, 2029 at 12:00AM GMT
   </div>
 </div>
 `;
@@ -584,7 +576,7 @@ exports[`renders human readable dates 3`] = `
   <div
     data-stylename="timeWindow"
   >
-    request ended Sun, Nov 29, 2020 at 12:00AM GMT
+    Ended: Sun, Nov 29, 2020 at 12:00AM GMT
   </div>
 </div>
 `;

--- a/src/routes/MemberProfile/MemberProfile.js
+++ b/src/routes/MemberProfile/MemberProfile.js
@@ -239,6 +239,7 @@ export function ActionDropdown ({ items }) {
 
   return activeItems.length > 0 &&
     <Dropdown
+      alignRight
       items={activeItems}
       toggleChildren={
         <Icon styleName='action-icon-button action-menu' name='More' alignRight />

--- a/src/routes/PostDetail/Comments/CommentForm/CommentForm.js
+++ b/src/routes/PostDetail/Comments/CommentForm/CommentForm.js
@@ -64,7 +64,7 @@ export default class CommentForm extends Component {
   render () {
     const { currentUser, className, addAttachment, focusOnRender, editorContent } = this.props
 
-    const placeholder = this.props.placeholder || (currentUser ? `Hi ${currentUser.firstName()}, what's on your mind?` : "Hi! What's on your mind?")
+    const placeholder = this.props.placeholder || 'Add a comment...'
 
     return <div
       styleName='commentForm'

--- a/src/routes/PostDetail/Comments/CommentForm/CommentForm.test.js
+++ b/src/routes/PostDetail/Comments/CommentForm/CommentForm.test.js
@@ -21,6 +21,6 @@ describe('CommentForm', () => {
     const wrapper = shallow(<CommentForm {...minDefaultProps} />)
     expect(wrapper.find('Connect(HyloEditor)').length).toEqual(1)
     expect(wrapper.find('Connect(HyloEditor)').prop('placeholder'))
-      .toEqual("Hi Jen, what's on your mind?")
+      .toEqual('Add a comment...')
   })
 })

--- a/src/routes/PostDetail/PostDetail.scss
+++ b/src/routes/PostDetail/PostDetail.scss
@@ -4,10 +4,6 @@
   overflow-x: hidden;
 }
 
-.header {
-  margin-bottom: 10px;
-}
-
 .header-sticky {
   position: fixed;
   top: 49px;


### PR DESCRIPTION
Fix issue where posts without a start/end time would always show as ENDED
Fixes #1025
Also cleanup display of post start and end times to be easier to read - don't uppercase text, better syntax.
Also if a post was "completed" before it ended show the end date as the date it was completed
Also tweak styling of post headers to look better - better positioning for spacer before announcement icon, and less whitespace below post header, calendar date doesnt overlap post header on mobile

Improve copy for comment box placeholder 
"Add a comment..." instead of reusing same copy from post box which is What's on your mind?
Geoff asked for this

Make sure you can see the dropdown to block a member 
Fixes #1024