### PR TITLE
Map drawer hidden by default on mobile, Saved Search linking and icon hover state fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Hylo Evo (the Hylo front-end) will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.4] - 2022-01-17
+
+## Changed
+- Hide MapExplorer drawer by default on mobile browsers and in Hylo App embed
+- Allow MapExplorer Saved Searches navigation to happen when in Hylo App embed
+- Fix hover state for MapExplorer on touch-based devices
+
 ## [3.2.3] - 2022-01-14
 
 ## Fixed 

--- a/src/routes/MapExplorer/MapExplorer.js
+++ b/src/routes/MapExplorer/MapExplorer.js
@@ -9,6 +9,7 @@ import center from '@turf/center'
 import combine from '@turf/combine'
 import { featureCollection, point } from '@turf/helpers'
 import { FlyToInterpolator } from 'react-map-gl'
+import isMobile from 'ismobilejs'
 import LayoutFlagsContext from 'contexts/LayoutFlagsContext'
 import { generateViewParams } from 'util/savedSearch'
 import { locationObjectToViewport } from 'util/geo'
@@ -70,14 +71,22 @@ export class UnwrappedMapExplorer extends React.Component {
   componentDidMount () {
     this.refs = {}
 
+    // Drawer hidden by default on mobile devices
+    if (isMobile) {
+      this.setState({ hideDrawer: true })
+    }
+
     // Relinquishes route handling within the Map entirely to Mobile App
-    // e.g. push.
+    // e.g. react router / history push
     const { mobileSettingsLayout } = this.context
     if (mobileSettingsLayout) {
       this.props.history.block(tx => {
-        const messageData = {
-          url: tx.pathname
-        }
+        const path = tx.pathname
+        // when in embedded view of map allow web navigation within map
+        // the keeps saved search retrieval from reseting group context in the app
+        if (path.match(/\/map$/)) return true
+        // url will be deprecated for path
+        const messageData = { path, url: path }
         window.ReactNativeWebView.postMessage(JSON.stringify(messageData))
         return false
       })

--- a/src/routes/MapExplorer/MapExplorer.scss
+++ b/src/routes/MapExplorer/MapExplorer.scss
@@ -221,9 +221,17 @@ button.toggleFeatureFiltersButton {
   &.open, &:hover {
     background-color: $color-caribbean-green;
     color: white;
-    font-size: 20px;
-    border-radius: 50px;
     cursor: pointer;  
+  }
+  // Necessary to keep simulated hover event on touch devices
+  // from sticking (Saved Search button was remaining
+  // highlighted after closed)
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: inherit;
+      color: inherit;
+      cursor: inherit;
+    }
   }
 }
 
@@ -254,7 +262,6 @@ button.toggleFeatureFiltersButton {
     margin-left: 10px;
   }
 }
-
 
 @media screen and (max-width: 600px) {
   .toggleDrawerButton.drawerOpen {


### PR DESCRIPTION
Final changes before embedded Map App release:

* Changes logic of map linking such that Saved Searches load doesn't send a message to the App. 
  * NOTE: This keeps Hylo App from reloading context to a new group, but has the down-side in the current design of leaving the user in their existing Group context but with map results potentially for a different group. The alternative for now was to have the map reload in mobile to move to the new group context (as it does on Web) but lose all the saved search attributes in the map load other than the Group context. If we make the MapExplorer page respond to URL search params corresponding to the saved search I can construct that URL when I reload the map in mobile. There are a couple other solutions, but all would have that similar result. Opened an issue to follow-up on this another time to determine the best solution later: https://github.com/Hylozoic/HyloReactNative/issues/521

* Makes drawer hidden on Map by default for all mobile devices
* Fixes sticky hover-state on Saved Searches button in mobile