### PR TITLE
A few more map fixes

### DIFF
--- a/src/routes/MapExplorer/MapExplorer.connector.js
+++ b/src/routes/MapExplorer/MapExplorer.connector.js
@@ -1,7 +1,8 @@
 import { push } from 'connected-react-router'
 import { connect } from 'react-redux'
-import { debounce, get, isEqual, isEmpty, pick, pickBy } from 'lodash/fp'
+import { get, isEqual, isEmpty, pick, pickBy } from 'lodash/fp'
 import changeQuerystringParam, { changeQuerystringParams } from 'store/actions/changeQuerystringParam'
+import { FETCH_FOR_GROUP } from 'store/constants'
 import presentPost from 'store/presenters/presentPost'
 import getGroupForCurrentRoute from 'store/selectors/getGroupForCurrentRoute'
 import getQuerystringParam from 'store/selectors/getQuerystringParam'
@@ -112,7 +113,7 @@ export function mapStateToProps (state, props) {
 
   const me = getMe(state)
   const centerParam = getQuerystringParam('center', state, props)
-  let centerLocation
+  let centerLocation, defaultZoom
   if (centerParam) {
     const decodedCenter = decodeURIComponent(centerParam).split(',')
     centerLocation = { lat: decodedCenter[0], lng: decodedCenter[1] }
@@ -120,12 +121,19 @@ export function mapStateToProps (state, props) {
     centerLocation = state.MapExplorer.centerLocation ||
       (group && group.locationObject ? group.locationObject.center
         : me && me.locationObject ? me.locationObject.center
-          : { lat: 35.442845, lng: 7.916598 })
+          : null)
   }
-  centerLocation = { lat: parseFloat(centerLocation.lat), lng: parseFloat(centerLocation.lng) }
+  if (centerLocation) {
+    centerLocation = { lat: parseFloat(centerLocation.lat), lng: parseFloat(centerLocation.lng) }
+    defaultZoom = 10
+  } else {
+    // Default to viewing whole map
+    centerLocation = { lat: 35.442845, lng: 7.916598 }
+    defaultZoom = 0
+  }
 
   let zoomParam = getQuerystringParam('zoom', state, props)
-  const zoom = zoomParam ? parseFloat(zoomParam) : state.MapExplorer.zoom || (centerLocation ? 10 : 0)
+  const zoom = zoomParam ? parseFloat(zoomParam) : state.MapExplorer.zoom || defaultZoom
 
   return {
     centerLocation,
@@ -139,6 +147,7 @@ export function mapStateToProps (state, props) {
     filters,
     group,
     groups,
+    groupPending: state.pending[FETCH_FOR_GROUP],
     hideDrawer,
     members,
     pendingPostsMap: state.pending[FETCH_POSTS_MAP],
@@ -196,15 +205,15 @@ export function mapDispatchToProps (dispatch, props) {
         updateUrlFromStore(params, true)
       })
     },
-    updateBoundingBox: debounce(800, bbox => dispatch(updateState({ totalBoundingBoxLoaded: bbox }))),
+    updateBoundingBox: bbox => dispatch(updateState({ totalBoundingBoxLoaded: bbox })),
     updateQueryParams: (params, replace) => updateUrlFromStore(params, replace),
-    updateView: debounce(800, ({ centerLocation, zoom }) => {
+    updateView: ({ centerLocation, zoom }) => {
       const newUrlParams = {
         zoom
       }
       newUrlParams['center'] = encodeURIComponent(centerLocation.lat + ',' + centerLocation.lng)
       dispatch(updateState({ centerLocation, zoom })).then(() => dispatch(changeQuerystringParams(props, newUrlParams, true)))
-    }),
+    },
     viewSavedSearch: (search) => {
       const { mapPath } = generateViewParams(search)
       dispatch(viewSavedSearch(search))

--- a/src/routes/MapExplorer/MapExplorer.connector.test.js
+++ b/src/routes/MapExplorer/MapExplorer.connector.test.js
@@ -63,6 +63,7 @@ describe('mapStateToProps', () => {
           topics: []
         },
         group: { id: 1, slug: 'foo' },
+        groupPending: undefined,
         groups: [],
         hideDrawer: false,
         members: [],
@@ -77,7 +78,7 @@ describe('mapStateToProps', () => {
         stateFilters: { featureTypes: { offer: true, request: true }, search: '', topics: [] },
         topics: [],
         totalBoundingBoxLoaded: undefined,
-        zoom: 10
+        zoom: 0
       })
     )
   })

--- a/src/routes/MapExplorer/MapExplorer.store.js
+++ b/src/routes/MapExplorer/MapExplorer.store.js
@@ -600,7 +600,7 @@ export const getGroupsFilteredByTopics = createSelector(
 
 /* ***** Reducer ***** */
 const DEFAULT_STATE = {
-  centerLocation: { lat: 35.442845, lng: 7.916598 },
+  centerLocation: null,
   totalBoundingBoxLoaded: null,
   zoom: 0,
   clientFilterParams: {


### PR DESCRIPTION
   Get debounce to actually work so we are not doing way too many updates to the map display that was causing things to slow down
 
 Make sure we load the group's location when loading a map for a group that has one and center the map on that location as the default if it exists
    
Make sure public map defaults to show whole map when the person does not have a location set in their profile
