### PR TITLE
Changes needed for using Group Detail in WebView on HyloApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Hylo App WebView events/interface to `GroupDetail` and related components
+
+### Changed
+- Behaviour of "Opportunies to Connect" on Group Detail to create a New Message via Moderator personIds
+
 ## [4.0.1] - 2022-06-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "html-webpack-plugin": "^4.5.1",
     "http-proxy-middleware": "0.17.4",
     "husky": "^7.0.4",
-    "hylo-shared": "^1.6.9",
+    "hylo-shared": "1.7.0",
     "identity-obj-proxy": "3.0.0",
     "immutable": "~3.7.4",
     "inflection": "^1.13.2",

--- a/src/components/Widget/OpportunitiesToCollaborateWidget/OpportunitiesToCollaborateWidget.js
+++ b/src/components/Widget/OpportunitiesToCollaborateWidget/OpportunitiesToCollaborateWidget.js
@@ -1,10 +1,9 @@
 import React, { useCallback } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import Icon from 'components/Icon'
 import useRouter from 'hooks/useRouter'
 import useEnsureCurrentGroup from 'hooks/useEnsureCurrentGroup'
 import { getFarmOpportunities } from 'store/selectors/farmExtensionSelectors'
-import { messageGroupModerators } from '../Widget.store'
 import getMe from 'store/selectors/getMe'
 
 import './OpportunitiesToCollaborate.scss'
@@ -23,16 +22,14 @@ export default function OpportunitiesToCollaborateWidget () {
 }
 
 export function OpportunityToCollaborate ({ group, opportunity }) {
-  const dispatch = useDispatch()
   const currentUser = useSelector(state => getMe(state))
   const { push } = useRouter()
   const prompt = `Hi there ${group.name}, I'd like to talk about ${promptLookup[opportunity]}.`
   const goToGroupModeratorsMessage = useCallback(() => {
     (async function () {
-      const response = await dispatch(messageGroupModerators(group.id))
-      const groupModeratorsThreadId = response.payload?.getData()
+      const messageToModeratorsPath = `/messages/new?participants=${group.moderators.map(m => m.id).join(',')}&prompt=${encodeURIComponent(prompt)}`
 
-      groupModeratorsThreadId && push(`/messages/${groupModeratorsThreadId}?prompt=${encodeURIComponent(prompt)}`)
+      push(messageToModeratorsPath)
     }())
   }, [group?.id, prompt])
 

--- a/src/components/Widget/OpportunitiesToCollaborateWidget/OpportunitiesToCollaborateWidget.js
+++ b/src/components/Widget/OpportunitiesToCollaborateWidget/OpportunitiesToCollaborateWidget.js
@@ -1,10 +1,11 @@
 import React, { useCallback } from 'react'
 import { useSelector } from 'react-redux'
-import Icon from 'components/Icon'
+import { newMessageUrl } from 'util/navigation'
 import useRouter from 'hooks/useRouter'
 import useEnsureCurrentGroup from 'hooks/useEnsureCurrentGroup'
 import { getFarmOpportunities } from 'store/selectors/farmExtensionSelectors'
 import getMe from 'store/selectors/getMe'
+import Icon from 'components/Icon'
 
 import './OpportunitiesToCollaborate.scss'
 
@@ -26,11 +27,9 @@ export function OpportunityToCollaborate ({ group, opportunity }) {
   const { push } = useRouter()
   const prompt = `Hi there ${group.name}, I'd like to talk about ${promptLookup[opportunity]}.`
   const goToGroupModeratorsMessage = useCallback(() => {
-    (async function () {
-      const messageToModeratorsPath = `/messages/new?participants=${group.moderators.map(m => m.id).join(',')}&prompt=${encodeURIComponent(prompt)}`
-
-      push(messageToModeratorsPath)
-    }())
+    push(
+      `${newMessageUrl()}?participants=${group.moderators.map(m => m.id).join(',')}&prompt=${encodeURIComponent(prompt)}`
+    )
   }, [group?.id, prompt])
 
   return (

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -1,7 +1,8 @@
 import cx from 'classnames'
 import { get, keyBy, map, trim } from 'lodash'
 import React, { Component, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useHistory } from 'react-router-dom'
+import LayoutFlagsContext from 'contexts/LayoutFlagsContext'
 import PropTypes from 'prop-types'
 import { TextHelpers } from 'hylo-shared'
 import Avatar from 'components/Avatar'
@@ -26,7 +27,6 @@ import {
 } from 'store/models/Group'
 import { inIframe } from 'util/index'
 import { groupDetailUrl, groupUrl, personUrl } from 'util/navigation'
-
 import g from './GroupDetail.scss' // eslint-disable-line no-unused-vars
 import m from '../MapExplorer/MapDrawer/MapDrawer.scss' // eslint-disable-line no-unused-vars
 
@@ -36,7 +36,7 @@ export const initialState = {
   membership: undefined,
   request: undefined
 }
-export default class GroupDetail extends Component {
+export class UnwrappedGroupDetail extends Component {
   static propTypes = {
     group: PropTypes.object,
     routeParams: PropTypes.object,
@@ -44,11 +44,27 @@ export default class GroupDetail extends Component {
     fetchGroup: PropTypes.func
   }
 
+  static contextType = LayoutFlagsContext
+
   state = initialState
 
   componentDidMount () {
     this.onGroupChange()
     this.props.fetchJoinRequests()
+    const { hyloAppLayout } = this.context
+
+    // Relinquishes route handling within the Map entirely to Mobile App
+    // e.g. react router / history push
+    if (hyloAppLayout) {
+      this.props.history.block(tx => {
+        const { pathname, search } = tx
+        const messageData = { pathname, search }
+
+        window.ReactNativeWebView.postMessage(JSON.stringify(messageData))
+
+        return false
+      })
+    }
   }
 
   componentDidUpdate (prevProps) {
@@ -374,5 +390,13 @@ export function SuggestedSkills ({ addSkill, currentUser, group, removeSkill }) 
         />
       </div>
     </div>
+  )
+}
+
+export default function GroupDetail (props) {
+  const history = useHistory()
+
+  return (
+    <UnwrappedGroupDetail {...props} history={history} />
   )
 }

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -79,9 +79,17 @@ export class UnwrappedGroupDetail extends Component {
     this.setState(initialState)
   }
 
-  joinGroup = (groupId) => {
-    const { joinGroup } = this.props
-    joinGroup(groupId)
+  joinGroup = async (groupId) => {
+    const { hyloAppLayout } = this.context
+    const { joinGroup, group } = this.props
+
+    await joinGroup(group.id)
+
+    if (hyloAppLayout) {
+      const messageData = { eventName: 'JOIN_GROUP', groupSlug: group.slug }
+
+      window.ReactNativeWebView.postMessage(JSON.stringify(messageData))
+    }
   }
 
   requestToJoinGroup = (groupId, questionAnswers) => {

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -36,6 +36,10 @@ export const initialState = {
   membership: undefined,
   request: undefined
 }
+
+// TODO: Move into hylo-shared and use in related code here and on Web
+export const JOINED_GROUP = 'JOINED_GROUP'
+
 export class UnwrappedGroupDetail extends Component {
   static propTypes = {
     group: PropTypes.object,
@@ -86,7 +90,7 @@ export class UnwrappedGroupDetail extends Component {
     await joinGroup(group.id)
 
     if (hyloAppLayout) {
-      const messageData = { eventName: 'JOIN_GROUP', groupSlug: group.slug }
+      const messageData = { eventName: JOINED_GROUP, groupSlug: group.slug }
 
       window.ReactNativeWebView.postMessage(JSON.stringify(messageData))
     }

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -2,9 +2,9 @@ import cx from 'classnames'
 import { get, keyBy, map, trim } from 'lodash'
 import React, { Component, useState } from 'react'
 import { Link, useHistory } from 'react-router-dom'
-import LayoutFlagsContext from 'contexts/LayoutFlagsContext'
 import PropTypes from 'prop-types'
-import { TextHelpers } from 'hylo-shared'
+import LayoutFlagsContext from 'contexts/LayoutFlagsContext'
+import { TextHelpers, HyloApp } from 'hylo-shared'
 import Avatar from 'components/Avatar'
 import FarmGroupDetailBody from 'components/FarmGroupDetailBody'
 import GroupAboutVideoEmbed from 'components/GroupAboutVideoEmbed'
@@ -37,9 +37,6 @@ export const initialState = {
   request: undefined
 }
 
-// TODO: Move into hylo-shared and use in related code here and on Web
-export const JOINED_GROUP = 'JOINED_GROUP'
-
 export class UnwrappedGroupDetail extends Component {
   static propTypes = {
     group: PropTypes.object,
@@ -60,12 +57,8 @@ export class UnwrappedGroupDetail extends Component {
     // Relinquishes route handling within the Map entirely to Mobile App
     // e.g. react router / history push
     if (hyloAppLayout) {
-      this.props.history.block(tx => {
-        const { pathname, search } = tx
-        const messageData = { pathname, search }
-
-        window.ReactNativeWebView.postMessage(JSON.stringify(messageData))
-
+      this.props.history.block(({ pathname, search }) => {
+        HyloApp.sendMessageToWebView(HyloApp.NAVIGATION, { pathname, search })
         return false
       })
     }
@@ -90,9 +83,7 @@ export class UnwrappedGroupDetail extends Component {
     await joinGroup(group.id)
 
     if (hyloAppLayout) {
-      const messageData = { eventName: JOINED_GROUP, groupSlug: group.slug }
-
-      window.ReactNativeWebView.postMessage(JSON.stringify(messageData))
+      HyloApp.sendMessageToWebView(HyloApp.JOINED_GROUP, { groupSlug: group.slug })
     }
   }
 

--- a/src/routes/MapExplorer/MapExplorer.js
+++ b/src/routes/MapExplorer/MapExplorer.js
@@ -9,6 +9,8 @@ import booleanWithin from '@turf/boolean-within'
 import center from '@turf/center'
 import combine from '@turf/combine'
 import { featureCollection, point } from '@turf/helpers'
+import { HyloApp } from 'hylo-shared'
+import { FEATURE_TYPES, formatBoundingBox } from './MapExplorer.store'
 import Dropdown from 'components/Dropdown'
 import Icon from 'components/Icon'
 import Loading from 'components/Loading'
@@ -25,7 +27,6 @@ import { isMobileDevice } from 'util/mobile'
 import { generateViewParams } from 'util/savedSearch'
 
 import MapDrawer from './MapDrawer'
-import { FEATURE_TYPES, formatBoundingBox } from './MapExplorer.store'
 import SavedSearches from './SavedSearches'
 
 import styles from './MapExplorer.scss'
@@ -106,16 +107,12 @@ export class UnwrappedMapExplorer extends React.Component {
     // Relinquishes route handling within the Map entirely to Mobile App
     // e.g. react router / history push
     if (hyloAppLayout) {
-      this.props.history.block(tx => {
-        const { pathname, search } = tx
-
+      this.props.history.block(({ pathname, search }) => {
         // when in embedded view of map allow web navigation within map
         // the keeps saved search retrieval from reseting group context in the app
         if (pathname.match(/\/map$/)) return true
 
-        const messageData = { pathname, search }
-
-        window.ReactNativeWebView.postMessage(JSON.stringify(messageData))
+        HyloApp.sendMessageToWebView(HyloApp.NAVIGATION, { pathname, search })
 
         return false
       })

--- a/src/routes/MapExplorer/MapExplorer.js
+++ b/src/routes/MapExplorer/MapExplorer.js
@@ -101,10 +101,10 @@ export class UnwrappedMapExplorer extends React.Component {
       this.setState({ hideDrawer: true })
     }
 
-    // Relinquishes route handling within the Map entirely to Mobile App
-    // e.g. react router / history push
     const { hyloAppLayout } = this.context
 
+    // Relinquishes route handling within the Map entirely to Mobile App
+    // e.g. react router / history push
     if (hyloAppLayout) {
       this.props.history.block(tx => {
         const { pathname, search } = tx
@@ -113,8 +113,7 @@ export class UnwrappedMapExplorer extends React.Component {
         // the keeps saved search retrieval from reseting group context in the app
         if (pathname.match(/\/map$/)) return true
 
-        // url will be deprecated for pathname and search
-        const messageData = { pathname, search, url: pathname }
+        const messageData = { pathname, search }
 
         window.ReactNativeWebView.postMessage(JSON.stringify(messageData))
 

--- a/src/routes/Messages/Messages.js
+++ b/src/routes/Messages/Messages.js
@@ -56,6 +56,7 @@ export default class Messages extends React.Component {
     if (prompt) {
       this.updateMessageText(prompt)
       this.props.changeQuerystringParam(this.props, 'prompt', null)
+      this.focusForm()
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9867,10 +9867,10 @@ husky@^7.0.4:
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
   integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
 
-hylo-shared@^1.6.9:
-  version "1.6.9"
-  resolved "https://registry.yarnpkg.com/hylo-shared/-/hylo-shared-1.6.9.tgz#5c1c2e168f8cc0c4acaf465d77cdba8b8177547d"
-  integrity sha512-KQRtuIGm19zUkGhCs16hfG2NvZ7z5r3iT3aO6aTl2H8PKlW6QL/naxINFNn5eESbdCkJPUVlwabm3OaWOyUXDQ==
+hylo-shared@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/hylo-shared/-/hylo-shared-1.7.0.tgz#0a59ab435259663c67ad9ce89fee2a0f1eff427b"
+  integrity sha512-Q8Wt4jqlJTs6eHixkx8wvXRdlozMK4o0MCjwWzZ5sg/uXr/nJRcucUGp9Wy6ThM2ls09Oz+Em9IrIVM5S/cX8A==
   dependencies:
     cheerio "^1.0.0-rc.10"
     coordinate-parser "^1.0.7"


### PR DESCRIPTION
Required for release of https://github.com/Hylozoic/HyloReactNative/pull/554 which makes Group Details in Hylo App a WebView of Hylo Web's Group Detail page, including integrated handling of farm-specific group widgets/features into the App.

* In addition to stuff for the Group Detail WebView, this branch adds some handling of Join and Leave Group events between Web and the App (still a couple rough spots we'll iron-out later)
* This changeset codifies WebView message handling between Web and the App through a shared object in `hylo-shared`. This will make the use of WebViews a good step cleaner.