### PR TITLE
`HyloHTML` component for all `dangerouslySetInnerHTML` calls

### DIFF
--- a/src/components/CommentCard/CommentCard.js
+++ b/src/components/CommentCard/CommentCard.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import RoundImage from 'components/RoundImage'
 import { TextHelpers } from 'hylo-shared'
 import Highlight from 'components/Highlight'
+import HyloHTML from 'components/HyloHTML'
 import ClickCatcher from 'components/ClickCatcher'
 import CardImageAttachments from 'components/CardImageAttachments'
 import CardFileAttachments from 'components/CardFileAttachments'
@@ -35,7 +36,7 @@ export default function CommentCard ({
         <CardFileAttachments attachments={attachments} styleName='comment-files' />
         <ClickCatcher groupSlug={slug}>
           <Highlight {...highlightProps}>
-            <div styleName='comment-body' dangerouslySetInnerHTML={{ __html: commentText }} />
+            <HyloHTML styleName='comment-body' html={commentText} />
           </Highlight>
         </ClickCatcher>
         <div styleName='comment-footer' />

--- a/src/components/CommentCard/__snapshots__/CommentCard.test.js.snap
+++ b/src/components/CommentCard/__snapshots__/CommentCard.test.js.snap
@@ -71,13 +71,9 @@ exports[`displays image an image attachments 1`] = `
         highlightClassName="highlight"
         term="foo"
       >
-        <div
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the …</p>",
-            }
-          }
+        <HyloHTML
           data-stylename="comment-body"
+          html="<p>text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the …</p>"
         />
       </Highlight>
     </ClickCatcher>
@@ -145,13 +141,9 @@ exports[`matches last snapshot 1`] = `
         highlightClassName="highlight"
         term="foo"
       >
-        <div
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the …</p>",
-            }
-          }
+        <HyloHTML
           data-stylename="comment-body"
+          html="<p>text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the …</p>"
         />
       </Highlight>
     </ClickCatcher>
@@ -219,13 +211,9 @@ exports[`matches last snapshot with different config 1`] = `
         highlightClassName="highlight"
         term="foo"
       >
-        <div
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<p>text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. Irrelevant Change</p>",
-            }
-          }
+        <HyloHTML
           data-stylename="comment-body"
+          html="<p>text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. text of the comment. a long one. Irrelevant Change</p>"
         />
       </Highlight>
     </ClickCatcher>

--- a/src/components/GroupCard/GroupCard.js
+++ b/src/components/GroupCard/GroupCard.js
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import { TextHelpers } from 'hylo-shared'
 import './GroupCard.scss'
 import GroupHeader from './GroupHeader'
+import HyloHTML from 'components/HyloHTML'
 import { Link } from 'react-router-dom'
 import { groupUrl, groupDetailUrl } from 'util/navigation'
 import Pill from 'components/Pill'
@@ -51,7 +52,7 @@ export default function GroupCard ({
         />
         {group.description
           ? <div styleName='group-description'>
-            <span dangerouslySetInnerHTML={{ __html: TextHelpers.markdown(group.description) }} />
+            <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
           </div>
           : ''
         }

--- a/src/components/GroupCard/__snapshots__/GroupCard.test.js.snap
+++ b/src/components/GroupCard/__snapshots__/GroupCard.test.js.snap
@@ -37,13 +37,10 @@ exports[`matches last snapshot 1`] = `
     <div
       data-stylename="group-description"
     >
-      <span
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>the description the description the description the description the description </p>
-",
-          }
-        }
+      <HyloHTML
+        element="span"
+        html="<p>the description the description the description the description the description </p>
+"
       />
     </div>
     <div
@@ -115,13 +112,10 @@ exports[`matches last snapshot with different config 1`] = `
     <div
       data-stylename="group-description"
     >
-      <span
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>the description the description the description the description the description </p>
-",
-          }
-        }
+      <HyloHTML
+        element="span"
+        html="<p>the description the description the description the description the description </p>
+"
       />
     </div>
     <div

--- a/src/components/HyloHTML/HyloHTML.js
+++ b/src/components/HyloHTML/HyloHTML.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+export default function HyloHTML ({
+  html,
+  element = 'div',
+  ...props
+}) {
+  return (
+    React.createElement(
+      element,
+      {
+        ...props,
+        dangerouslySetInnerHTML: { __html: html }
+      }
+    )
+  )
+}

--- a/src/components/HyloHTML/index.js
+++ b/src/components/HyloHTML/index.js
@@ -1,0 +1,3 @@
+import component from './HyloHTML'
+
+export default component

--- a/src/components/HyloTipTapEditor/HyloTipTapRender.js
+++ b/src/components/HyloTipTapEditor/HyloTipTapRender.js
@@ -48,6 +48,6 @@ export default function HyloTipTapRender ({ className, contentHTML }) {
 //   }, [contentHTML])
 //
 //   return (
-//     <div className={className} dangerouslySetInnerHTML={{ __html: output }} />
+//     <HyloHTML className={className} html={output} />
 //   )
 // }

--- a/src/components/PostBigGridItem/PostBigGridItem.js
+++ b/src/components/PostBigGridItem/PostBigGridItem.js
@@ -3,6 +3,7 @@ import Clamp from 'react-multiline-clamp'
 import cx from 'classnames'
 import EventDate from 'components/PostCard/EventDate'
 import EventRSVP from 'components/PostCard/EventRSVP'
+import HyloHTML from 'components/HyloHTML'
 import { personUrl } from 'util/navigation'
 import { TextHelpers } from 'hylo-shared'
 import Avatar from 'components/Avatar'
@@ -71,7 +72,7 @@ export default function PostBigGridItem (props) {
           : ' '
         }
 
-        <div styleName='details' dangerouslySetInnerHTML={{ __html: details }} onClick={showDetailsTargeted} />
+        <HyloHTML styleName='details' html={details} onClick={showDetailsTargeted} />
         <div styleName='grid-meta'>
           {post.type === 'event' &&
             <div styleName='date' onClick={showDetailsTargeted}>
@@ -81,7 +82,7 @@ export default function PostBigGridItem (props) {
           <h3 styleName='title' onClick={showDetails}>{title}</h3>
           <div styleName='content-snippet'>
             <Clamp lines={2}>
-              <div styleName='details' dangerouslySetInnerHTML={{ __html: details }} onClick={showDetailsTargeted} />
+              <HyloHTML styleName='details' html={details} onClick={showDetailsTargeted} />
             </Clamp>
             <div styleName='fade' />
           </div>

--- a/src/components/PostCard/PostDetails/PostDetails.js
+++ b/src/components/PostCard/PostDetails/PostDetails.js
@@ -3,6 +3,7 @@ import { pick } from 'lodash/fp'
 import { TextHelpers } from 'hylo-shared'
 import ReactPlayer from 'react-player'
 import Highlight from 'components/Highlight'
+import HyloHTML from 'components/HyloHTML'
 import ClickCatcher from 'components/ClickCatcher'
 import CardFileAttachments from 'components/CardFileAttachments'
 import Feature from 'components/PostCard/Feature'
@@ -42,7 +43,7 @@ export default function PostDetails ({
         )}
         {details && !hideDetails && (
           <ClickCatcher groupSlug={slug}>
-            <div styleName='details' dangerouslySetInnerHTML={{ __html: details }} />
+            <HyloHTML styleName='details' html={details} />
           </ClickCatcher>
         )}
         {linkPreview && !linkPreviewFeatured && (

--- a/src/components/PostCard/PostDetails/__snapshots__/PostDetails.test.js.snap
+++ b/src/components/PostCard/PostDetails/__snapshots__/PostDetails.test.js.snap
@@ -15,13 +15,9 @@ exports[`matches last snapshot 1`] = `
     <ClickCatcher
       groupSlug="foomunity"
     >
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "the details",
-          }
-        }
+      <HyloHTML
         data-stylename="details"
+        html="the details"
       />
     </ClickCatcher>
     <LinkPreview

--- a/src/components/PostGridItem/PostGridItem.js
+++ b/src/components/PostGridItem/PostGridItem.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 import { personUrl } from 'util/navigation'
 import { TextHelpers } from 'hylo-shared'
 import Avatar from 'components/Avatar'
+import HyloHTML from 'components/HyloHTML'
 import Icon from 'components/Icon'
 import './PostGridItem.scss'
 
@@ -67,7 +68,7 @@ export default function PostGridItem (props) {
             : ' '
         }
 
-        <div styleName='details' dangerouslySetInnerHTML={{ __html: details }} />
+        <HyloHTML styleName='details' html={details} />
         <div styleName='grid-meta'>
           <div styleName='type-author'>
             <Avatar avatarUrl={creator.avatarUrl} url={creatorUrl} styleName='avatar' tiny />

--- a/src/components/PostListRow/PostListRow.js
+++ b/src/components/PostListRow/PostListRow.js
@@ -6,6 +6,7 @@ import { isEmpty } from 'lodash/fp'
 import { personUrl, topicUrl } from 'util/navigation'
 import { TextHelpers } from 'hylo-shared'
 import Avatar from 'components/Avatar'
+import HyloHTML from 'components/HyloHTML'
 import Icon from 'components/Icon'
 import Tooltip from 'components/Tooltip'
 import './PostListRow.scss'
@@ -85,7 +86,7 @@ const PostListRow = (props) => {
           </div>
         )}
         <h3 styleName='title'>{title}</h3>
-        <div styleName='details' dangerouslySetInnerHTML={{ __html: details }} />
+        <HyloHTML styleName='details' html={details} />
       </div>
       <Tooltip
         delay={550}

--- a/src/components/Widget/GroupsWidget/GroupsWidget.js
+++ b/src/components/Widget/GroupsWidget/GroupsWidget.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import Slider from 'react-slick'
 import { TextHelpers } from 'hylo-shared'
+import HyloHTML from 'components/HyloHTML'
 import { DEFAULT_BANNER, DEFAULT_AVATAR } from 'store/models/Group'
 import { createGroupUrl, groupUrl, groupDetailUrl } from 'util/navigation'
 
@@ -66,7 +67,7 @@ export function GroupCard ({ group, routeParams, className }) {
           <div styleName='group-name'>{group.name}</div>
           <div styleName='member-count'>{group.memberCount} member{group.memberCount !== 1 ? 's' : ''}</div>
           <div styleName='group-description'>
-            <span dangerouslySetInnerHTML={{ __html: TextHelpers.markdown(group.description) }} />
+            <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
             {group.description && group.description.length > 140 && <div styleName='descriptionFade' />}
           </div>
           {group.memberStatus === 'member'

--- a/src/components/Widget/GroupsWidget/__snapshots__/GroupsWidget.test.js.snap
+++ b/src/components/Widget/GroupsWidget/__snapshots__/GroupsWidget.test.js.snap
@@ -590,14 +590,20 @@ exports[`GroupsWidget renders correctly with items 1`] = `
                                 <div
                                   data-stylename="group-description"
                                 >
-                                  <span
-                                    dangerouslySetInnerHTML={
-                                      Object {
-                                        "__html": "<p>yo</p>
+                                  <HyloHTML
+                                    element="span"
+                                    html="<p>yo</p>
+"
+                                  >
+                                    <span
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "<p>yo</p>
 ",
+                                        }
                                       }
-                                    }
-                                  />
+                                    />
+                                  </HyloHTML>
                                 </div>
                                 <div
                                   data-stylename="isnt-member"
@@ -716,14 +722,20 @@ exports[`GroupsWidget renders correctly with items 1`] = `
                                 <div
                                   data-stylename="group-description"
                                 >
-                                  <span
-                                    dangerouslySetInnerHTML={
-                                      Object {
-                                        "__html": "<p>oy</p>
+                                  <HyloHTML
+                                    element="span"
+                                    html="<p>oy</p>
+"
+                                  >
+                                    <span
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "<p>oy</p>
 ",
+                                        }
                                       }
-                                    }
-                                  />
+                                    />
+                                  </HyloHTML>
                                 </div>
                                 <div
                                   data-stylename="isnt-member"

--- a/src/components/Widget/RichTextWidget/RichTextWidget.js
+++ b/src/components/Widget/RichTextWidget/RichTextWidget.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import GroupAboutVideoEmbed from 'components/GroupAboutVideoEmbed'
+import HyloHTML from 'components/HyloHTML'
 import './RichText.scss'
 
 export default function RichTextWidget ({ group, settings }) {
@@ -8,7 +9,7 @@ export default function RichTextWidget ({ group, settings }) {
       <GroupAboutVideoEmbed uri={settings.embeddedVideoURI} />
       <h2>{settings.title || `Welcome to ${group.name}!`}</h2>
       {settings.richText && (
-        <span dangerouslySetInnerHTML={{ __html: settings.richText }} />
+        <HyloHTML element='span' html={settings.richText} />
       )}
       {settings.text && (
         <p>{settings.text}</p>

--- a/src/components/Widget/WelcomeWidget/WelcomeWidget.js
+++ b/src/components/Widget/WelcomeWidget/WelcomeWidget.js
@@ -1,7 +1,7 @@
 import { TextHelpers } from 'hylo-shared'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-
+import HyloHTML from 'components/HyloHTML'
 import './WelcomeWidget.scss'
 
 const { object } = PropTypes
@@ -17,7 +17,7 @@ export default class WelcomeWidget extends Component {
     return (
       <div styleName='welcome-widget'>
         <h2>{settings.title || `Welcome to ${group.name}!`}</h2>
-        <p dangerouslySetInnerHTML={{ __html: TextHelpers.markdown(message) }} />
+        <HyloHTML element='p' html={TextHelpers.markdown(message)} />
       </div>
     )
   }

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -9,6 +9,7 @@ import { sendMessageToWebView } from 'util/webView'
 import Avatar from 'components/Avatar'
 import FarmGroupDetailBody from 'components/FarmGroupDetailBody'
 import GroupAboutVideoEmbed from 'components/GroupAboutVideoEmbed'
+import HyloHTML from 'components/HyloHTML'
 import Icon from 'components/Icon'
 import SocketSubscriber from 'components/SocketSubscriber'
 import Loading from 'components/Loading'
@@ -209,7 +210,7 @@ export class UnwrappedGroupDetail extends Component {
           ) : (
             <div styleName='g.groupDescription'>
               <GroupAboutVideoEmbed uri={group.aboutVideoUri} styleName='g.groupAboutVideo' />
-              <span dangerouslySetInnerHTML={{ __html: TextHelpers.markdown(group.description) }} />
+              <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
             </div>
           )}
         {!isAboutCurrentGroup && topics && topics.length && (

--- a/src/routes/GroupSidebar/GroupSidebar.js
+++ b/src/routes/GroupSidebar/GroupSidebar.js
@@ -1,15 +1,16 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
+import { isEmpty } from 'lodash/fp'
+import { TextHelpers } from 'hylo-shared'
+import { personUrl, groupUrl } from 'util/navigation'
 import Avatar from 'components/Avatar'
 import Loading from 'components/Loading'
 import RoundImageRow from 'components/RoundImageRow'
 import Button from 'components/Button'
+import HyloHTML from 'components/HyloHTML'
 import Icon from 'components/Icon'
 import cx from 'classnames'
-import { personUrl, groupUrl } from 'util/navigation'
-import { TextHelpers } from 'hylo-shared'
-import { isEmpty } from 'lodash/fp'
 import './GroupSidebar.scss'
 
 const { object, string, array } = PropTypes
@@ -74,7 +75,7 @@ export class AboutSection extends Component {
       </div>
       <div styleName={cx('description', { expanded })}>
         {!expanded && <div styleName='gradient' />}
-        <span dangerouslySetInnerHTML={{ __html: TextHelpers.markdown(description) }} />
+        <HyloHTML element='span' html={TextHelpers.markdown(description)} />
       </div>
       {showExpandButton && <span styleName='expand-button' onClick={onClick}>
         {expanded ? 'Show Less' : 'Read More'}

--- a/src/routes/GroupSidebar/GroupSidebar.test.js
+++ b/src/routes/GroupSidebar/GroupSidebar.test.js
@@ -45,9 +45,9 @@ describe('AboutSection', () => {
         name={group.name}
         description={group.description} />)
     expect(wrapper.find('div').at(1).text()).toEqual(`About ${group.name}`)
-    expect(wrapper.find('span').at(1).text()).toEqual('Read More')
+    expect(wrapper.find('span').at(0).text()).toEqual('Read More')
     wrapper.setState({ expanded: true })
-    expect(wrapper.find('span').at(1).text()).toEqual('Show Less')
+    expect(wrapper.find('span').at(0).text()).toEqual('Show Less')
   })
 })
 

--- a/src/routes/Groups/Groups.js
+++ b/src/routes/Groups/Groups.js
@@ -5,6 +5,7 @@ import { TextHelpers } from 'hylo-shared'
 import Icon from 'components/Icon'
 import RoundImage from 'components/RoundImage'
 import GroupNetworkMap from 'components/GroupNetworkMap'
+import HyloHTML from 'components/HyloHTML'
 import {
   DEFAULT_BANNER,
   DEFAULT_AVATAR,
@@ -111,7 +112,7 @@ export function GroupCard ({ group, routeParams }) {
             </div>
           </div>
           <div styleName='group-description'>
-            <span dangerouslySetInnerHTML={{ __html: TextHelpers.markdown(group.description) }} />
+            <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
           </div>
         </div>
       </div>

--- a/src/routes/Messages/Message/Message.js
+++ b/src/routes/Messages/Message/Message.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import cx from 'classnames'
 import Avatar from 'components/Avatar'
+import HyloHTML from 'components/HyloHTML'
 import { personUrl } from 'util/navigation'
 import { TextHelpers } from 'hylo-shared'
 import './Message.scss'
@@ -28,7 +29,7 @@ export default function Message ({ message, isHeader }) {
           <span styleName='date'>{pending ? 'sending...' : TextHelpers.humanDate(message.createdAt)}</span>
         </div>}
         <div styleName='text'>
-          <span dangerouslySetInnerHTML={{ __html: text }} />
+          <HyloHTML element='span' html={text} />
         </div>
       </div>
     </div>

--- a/src/routes/Messages/Message/__snapshots__/Message.test.js.snap
+++ b/src/routes/Messages/Message/__snapshots__/Message.test.js.snap
@@ -31,12 +31,9 @@ exports[`to display sending... when message is still in optimistic state 1`] = `
     <div
       data-stylename="text"
     >
-      <span
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "sending...",
-          }
-        }
+      <HyloHTML
+        element="span"
+        html="sending..."
       />
     </div>
   </div>
@@ -57,13 +54,10 @@ exports[`to match the latest non-header snapshot 1`] = `
     <div
       data-stylename="text"
     >
-      <span
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>test</p>
-",
-          }
-        }
+      <HyloHTML
+        element="span"
+        html="<p>test</p>
+"
       />
     </div>
   </div>
@@ -99,13 +93,10 @@ exports[`to match the latest snapshot 1`] = `
     <div
       data-stylename="text"
     >
-      <span
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>test</p>
-",
-          }
-        }
+      <HyloHTML
+        element="span"
+        html="<p>test</p>
+"
       />
     </div>
   </div>


### PR DESCRIPTION
Less dangerous! This is an addendum to #1258, not required but complementary and recommended. This shouldn't have much of any impact or cause new bugs (Search should be tested), but will keep us going in the direction of carefully handling our HTML. Can explain more if needed.

⚠️ To be clear going forward, if merged, when you go to type `dangerouslySetInnerHTML` you should instead be using `HyloHTML` in all cases (which I can foresee).