### PR TITLE
Make sure bold text is bold across the site

### DIFF
--- a/src/css/typography.scss
+++ b/src/css/typography.scss
@@ -40,6 +40,10 @@ ul, ol {
   padding-left: 2em;
 }
 
+strong {
+  @include font-bold;
+}
+
 // This should be applied / controlled here
 // Currently getting `1rem` from Bootstrap
 // p {

--- a/src/routes/Members/Members.scss
+++ b/src/routes/Members/Members.scss
@@ -72,10 +72,6 @@ $search-width: 460px;
 
   span {
     white-space: nowrap;
-
-    strong {
-      font-family: 'Circular Bold', sans-serif;
-    }
   }
 }
 

--- a/src/routes/PostDetail/Comments/Comment/Comment.scss
+++ b/src/routes/PostDetail/Comments/Comment/Comment.scss
@@ -71,7 +71,6 @@ $comment-row-padding: 25px;
   margin-left: $comment-left-margin;
 
   strong {
-    font-family: 'Circular Bold';
     color: rgba(66, 94, 114, 1.0);
   }
 }

--- a/src/routes/PostDetail/Comments/CommentForm/CommentForm.scss
+++ b/src/routes/PostDetail/Comments/CommentForm/CommentForm.scss
@@ -82,11 +82,6 @@
   overflow-wrap: break-word;
   cursor: text;
 
-  // Should this be applied as part of global typography styles?
-  // Those should be being applied the same in the editor as in display
-  span[style='font-weight: bold;'] {
-    font-family: 'Circular Bold';
-  }
   // Would be best on the container above but will be wrong height due
   // to `position: relative`
   [contenteditable="true"] {


### PR DESCRIPTION
All <strong> tags now use font Circular Bold since otherwise font-weight doesnt do anything. This is mainly to fix bold text in posts and comments but does apply everywhere.

Fixes https://github.com/Hylozoic/hylo-evo/issues/1333