### PR TITLE
1: HyloReactNative-544: Add Group Explore and About

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,11 +5,16 @@ import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { Provider } from 'react-redux'
 import { LayoutFlagsProvider } from 'contexts/LayoutFlagsContext'
+import isWebView from 'util/webView'
 import createStore, { history } from '../store'
 import RootRouter from 'routes/RootRouter'
 import HyloAppRouter from 'routes/HyloAppRouter'
 
 const store = createStore()
+
+if (isWebView()) {
+  window.ReactNativeWebView.reactRouterHistory = history
+}
 
 export default function App () {
   require('client/rollbar') // set up handling of uncaught errors

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -51,15 +51,6 @@ export class UnwrappedGroupDetail extends Component {
   componentDidMount () {
     this.onGroupChange()
     this.props.fetchJoinRequests()
-
-    // Relinquishes route handling within the Map entirely to Mobile App
-    // e.g. react router / history push
-    if (isWebView()) {
-      this.props.history.block(({ pathname, search }) => {
-        sendMessageToWebView(WebViewMessageTypes.NAVIGATION, { pathname, search })
-        return false
-      })
-    }
   }
 
   componentDidUpdate (prevProps) {
@@ -80,6 +71,7 @@ export class UnwrappedGroupDetail extends Component {
     await joinGroup(group.id)
 
     if (isWebView()) {
+      // Could be handled better using WebSockets
       sendMessageToWebView(WebViewMessageTypes.JOINED_GROUP, { groupSlug: group.slug })
     }
   }

--- a/src/routes/RootRouter/RootRouter.js
+++ b/src/routes/RootRouter/RootRouter.js
@@ -1,9 +1,8 @@
 import mixpanel from 'mixpanel-browser'
 import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useHistory, Route, Switch } from 'react-router'
+import { Route, Switch } from 'react-router'
 import config, { isProduction, isTest } from 'config'
-import { WebViewMessageTypes } from 'hylo-shared'
 import Loading from 'components/Loading'
 import AuthLayoutRouter from 'routes/AuthLayoutRouter'
 import PublicLayoutRouter from 'routes/PublicLayoutRouter'
@@ -11,7 +10,6 @@ import NonAuthLayoutRouter from 'routes/NonAuthLayoutRouter'
 import checkLogin from 'store/actions/checkLogin'
 import { getAuthorized } from 'store/selectors/getAuthState'
 import { POST_DETAIL_MATCH } from 'util/navigation'
-import isWebView, { sendMessageToWebView } from 'util/webView'
 
 if (!isTest) {
   mixpanel.init(config.mixpanel.token, { debug: !isProduction })
@@ -19,7 +17,6 @@ if (!isTest) {
 
 export default function RootRouter () {
   const dispatch = useDispatch()
-  const history = useHistory()
   const isAuthorized = useSelector(getAuthorized)
   const [loading, setLoading] = useState(true)
 
@@ -32,23 +29,6 @@ export default function RootRouter () {
       setLoading(false)
     }())
   }, [dispatch, checkLogin, setLoading])
-
-  useEffect(() => {
-    // NOTE: Overrides all navigation from a given page when in the the HyloApp WebView context.
-    // Navigation events are handled by HyloApp through listening for the WebView event type
-    // `WebViewMessageTypes.NAVIGATION`
-    if (isWebView()) {
-      history.block(({ pathname, search }) => {
-        // Special case for MapExplorer WebView which URL/history changing navigation within the map
-        // to keeps saved search retrieval from resetting group context in the app:
-        if (pathname.match(/\/map$/)) return true
-
-        sendMessageToWebView(WebViewMessageTypes.NAVIGATION, { pathname, search })
-
-        return false
-      })
-    }
-  }, [loading, isWebView])
 
   if (loading) {
     return (
@@ -63,7 +43,7 @@ export default function RootRouter () {
   }
 
   if (!isAuthorized) {
-    // TODO: Can NonAuthLayoutRouter and PublicLayourRouter merge?
+    // TODO: Can NonAuthLayoutRouter and PublicLayoutRouter merge?
     return (
       <Switch>
         <Route path='/post/:id' component={PublicLayoutRouter} />

--- a/src/routes/UserSettings/UserGroupsTab/UserGroupsTab.js
+++ b/src/routes/UserSettings/UserGroupsTab/UserGroupsTab.js
@@ -112,6 +112,7 @@ export default class UserGroupsTab extends Component {
         }
 
         if (isWebView()) {
+          // Could be handled better using WebSockets
           sendMessageToWebView(WebViewMessageTypes.LEFT_GROUP, { groupId: deletedGroupId })
         }
 

--- a/src/util/navigation.test.js
+++ b/src/util/navigation.test.js
@@ -1,8 +1,7 @@
 import {
   removePostFromUrl,
   postUrl,
-  gotoExternalUrl,
-  contextSwitchingUrl
+  gotoExternalUrl
 } from './navigation'
 
 describe('postUrl', () => {

--- a/src/util/webView.js
+++ b/src/util/webView.js
@@ -3,9 +3,9 @@ export function sendMessageToWebView (type, data) {
     throw new Error('Must provide a message `type` when sending a message to the WebView')
   }
 
-  window?.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({ type, data }))
+  isWebView() && window.ReactNativeWebView.postMessage(JSON.stringify({ type, data }))
 }
 
 export default function isWebView () {
-  return typeof window !== 'undefined' && window.HyloWebView
+  return typeof window !== 'undefined' && window.ReactNativeWebView
 }


### PR DESCRIPTION
I've made  number of small but important further refinements to how we're using WebViews on Mobile with respect to navigation within the page and back into the App. In the course of this I've moved control of such things into the WebViews through providing the WebView our React Router history object on the `window` global. 

Note: This is a necessary release is designed to accompany https://github.com/Hylozoic/HyloReactNative/pull/592. 