### PR TITLE
Fixes #1343 - Fix formatting and autolink group descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- `groupDescription` is now "autolinked" making external links added in the markdown clickable, including proper handling of Hylo links, mention, and topic links (via application of `ClickCatcher`)
+
+### Fixed
+- Styling of `groupDescription` to eliminate extra vertical space between paragraphs
+
+### Changed
+- Added default of `all` to `groupSlug` prop of `ClickCatcher`, doesn't change current behavior
+
 ## [5.0.2] - 2022-10-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "html-webpack-plugin": "^4.5.1",
     "http-proxy-middleware": "0.17.4",
     "husky": "^7.0.4",
-    "hylo-shared": "5.0.0",
+    "hylo-shared": "5.1.0",
     "identity-obj-proxy": "3.0.0",
     "immutability-helper": "^3.1.1",
     "immutable": "~3.7.4",

--- a/src/components/ClickCatcher/ClickCatcher.js
+++ b/src/components/ClickCatcher/ClickCatcher.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { useHistory } from 'react-router-dom'
 import { PathHelpers, HYLO_URL_REGEX } from 'hylo-shared'
 
-export default function ClickCatcher ({ handleMouseOver, groupSlug, ...props }) {
+export default function ClickCatcher ({ handleMouseOver, groupSlug = 'all', ...props }) {
   const history = useHistory()
 
   return React.createElement('span', { ...props, onClick: handleClick(history.push, groupSlug) })

--- a/src/components/GroupCard/GroupCard.js
+++ b/src/components/GroupCard/GroupCard.js
@@ -1,13 +1,14 @@
 import React from 'react'
-import cx from 'classnames'
+import { Link } from 'react-router-dom'
+import { capitalize } from 'lodash'
 import { TextHelpers } from 'hylo-shared'
-import './GroupCard.scss'
+import { groupUrl, groupDetailUrl } from 'util/navigation'
+import ClickCatcher from 'components/ClickCatcher'
 import GroupHeader from './GroupHeader'
 import HyloHTML from 'components/HyloHTML'
-import { Link } from 'react-router-dom'
-import { groupUrl, groupDetailUrl } from 'util/navigation'
 import Pill from 'components/Pill'
-import { capitalize } from 'lodash'
+import cx from 'classnames'
+import './GroupCard.scss'
 
 /*
   Each card needs
@@ -52,7 +53,9 @@ export default function GroupCard ({
         />
         {group.description
           ? <div styleName='group-description'>
-            <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
+            <ClickCatcher groupSlug='all'>
+              <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
+            </ClickCatcher>
           </div>
           : ''
         }

--- a/src/components/GroupCard/GroupCard.js
+++ b/src/components/GroupCard/GroupCard.js
@@ -53,7 +53,7 @@ export default function GroupCard ({
         />
         {group.description
           ? <div styleName='group-description'>
-            <ClickCatcher groupSlug='all'>
+            <ClickCatcher>
               <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
             </ClickCatcher>
           </div>

--- a/src/components/GroupCard/__snapshots__/GroupCard.test.js.snap
+++ b/src/components/GroupCard/__snapshots__/GroupCard.test.js.snap
@@ -37,9 +37,7 @@ exports[`matches last snapshot 1`] = `
     <div
       data-stylename="group-description"
     >
-      <ClickCatcher
-        groupSlug="all"
-      >
+      <ClickCatcher>
         <HyloHTML
           element="span"
           html="<p>the description the description the description the description the description </p>
@@ -116,9 +114,7 @@ exports[`matches last snapshot with different config 1`] = `
     <div
       data-stylename="group-description"
     >
-      <ClickCatcher
-        groupSlug="all"
-      >
+      <ClickCatcher>
         <HyloHTML
           element="span"
           html="<p>the description the description the description the description the description </p>

--- a/src/components/GroupCard/__snapshots__/GroupCard.test.js.snap
+++ b/src/components/GroupCard/__snapshots__/GroupCard.test.js.snap
@@ -37,11 +37,15 @@ exports[`matches last snapshot 1`] = `
     <div
       data-stylename="group-description"
     >
-      <HyloHTML
-        element="span"
-        html="<p>the description the description the description the description the description </p>
+      <ClickCatcher
+        groupSlug="all"
+      >
+        <HyloHTML
+          element="span"
+          html="<p>the description the description the description the description the description </p>
 "
-      />
+        />
+      </ClickCatcher>
     </div>
     <div
       data-stylename="group-tags"
@@ -112,11 +116,15 @@ exports[`matches last snapshot with different config 1`] = `
     <div
       data-stylename="group-description"
     >
-      <HyloHTML
-        element="span"
-        html="<p>the description the description the description the description the description </p>
+      <ClickCatcher
+        groupSlug="all"
+      >
+        <HyloHTML
+          element="span"
+          html="<p>the description the description the description the description the description </p>
 "
-      />
+        />
+      </ClickCatcher>
     </div>
     <div
       data-stylename="group-tags"

--- a/src/components/Widget/GroupsWidget/GroupsWidget.js
+++ b/src/components/Widget/GroupsWidget/GroupsWidget.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import Slider from 'react-slick'
 import { TextHelpers } from 'hylo-shared'
-import HyloHTML from 'components/HyloHTML'
-import { DEFAULT_BANNER, DEFAULT_AVATAR } from 'store/models/Group'
 import { createGroupUrl, groupUrl, groupDetailUrl } from 'util/navigation'
+import { DEFAULT_BANNER, DEFAULT_AVATAR } from 'store/models/Group'
+import ClickCatcher from 'components/ClickCatcher'
+import HyloHTML from 'components/HyloHTML'
 
 import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
@@ -67,7 +68,9 @@ export function GroupCard ({ group, routeParams, className }) {
           <div styleName='group-name'>{group.name}</div>
           <div styleName='member-count'>{group.memberCount} member{group.memberCount !== 1 ? 's' : ''}</div>
           <div styleName='group-description'>
-            <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
+            <ClickCatcher groupSlug='all'>
+              <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
+            </ClickCatcher>
             {group.description && group.description.length > 140 && <div styleName='descriptionFade' />}
           </div>
           {group.memberStatus === 'member'

--- a/src/components/Widget/GroupsWidget/GroupsWidget.js
+++ b/src/components/Widget/GroupsWidget/GroupsWidget.js
@@ -68,7 +68,7 @@ export function GroupCard ({ group, routeParams, className }) {
           <div styleName='group-name'>{group.name}</div>
           <div styleName='member-count'>{group.memberCount} member{group.memberCount !== 1 ? 's' : ''}</div>
           <div styleName='group-description'>
-            <ClickCatcher groupSlug='all'>
+            <ClickCatcher>
               <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
             </ClickCatcher>
             {group.description && group.description.length > 140 && <div styleName='descriptionFade' />}

--- a/src/components/Widget/GroupsWidget/__snapshots__/GroupsWidget.test.js.snap
+++ b/src/components/Widget/GroupsWidget/__snapshots__/GroupsWidget.test.js.snap
@@ -590,9 +590,7 @@ exports[`GroupsWidget renders correctly with items 1`] = `
                                 <div
                                   data-stylename="group-description"
                                 >
-                                  <ClickCatcher
-                                    groupSlug="all"
-                                  >
+                                  <ClickCatcher>
                                     <span
                                       onClick={[Function]}
                                     >
@@ -730,9 +728,7 @@ exports[`GroupsWidget renders correctly with items 1`] = `
                                 <div
                                   data-stylename="group-description"
                                 >
-                                  <ClickCatcher
-                                    groupSlug="all"
-                                  >
+                                  <ClickCatcher>
                                     <span
                                       onClick={[Function]}
                                     >

--- a/src/components/Widget/GroupsWidget/__snapshots__/GroupsWidget.test.js.snap
+++ b/src/components/Widget/GroupsWidget/__snapshots__/GroupsWidget.test.js.snap
@@ -590,20 +590,28 @@ exports[`GroupsWidget renders correctly with items 1`] = `
                                 <div
                                   data-stylename="group-description"
                                 >
-                                  <HyloHTML
-                                    element="span"
-                                    html="<p>yo</p>
-"
+                                  <ClickCatcher
+                                    groupSlug="all"
                                   >
                                     <span
-                                      dangerouslySetInnerHTML={
-                                        Object {
-                                          "__html": "<p>yo</p>
+                                      onClick={[Function]}
+                                    >
+                                      <HyloHTML
+                                        element="span"
+                                        html="<p>yo</p>
+"
+                                      >
+                                        <span
+                                          dangerouslySetInnerHTML={
+                                            Object {
+                                              "__html": "<p>yo</p>
 ",
-                                        }
-                                      }
-                                    />
-                                  </HyloHTML>
+                                            }
+                                          }
+                                        />
+                                      </HyloHTML>
+                                    </span>
+                                  </ClickCatcher>
                                 </div>
                                 <div
                                   data-stylename="isnt-member"
@@ -722,20 +730,28 @@ exports[`GroupsWidget renders correctly with items 1`] = `
                                 <div
                                   data-stylename="group-description"
                                 >
-                                  <HyloHTML
-                                    element="span"
-                                    html="<p>oy</p>
-"
+                                  <ClickCatcher
+                                    groupSlug="all"
                                   >
                                     <span
-                                      dangerouslySetInnerHTML={
-                                        Object {
-                                          "__html": "<p>oy</p>
+                                      onClick={[Function]}
+                                    >
+                                      <HyloHTML
+                                        element="span"
+                                        html="<p>oy</p>
+"
+                                      >
+                                        <span
+                                          dangerouslySetInnerHTML={
+                                            Object {
+                                              "__html": "<p>oy</p>
 ",
-                                        }
-                                      }
-                                    />
-                                  </HyloHTML>
+                                            }
+                                          }
+                                        />
+                                      </HyloHTML>
+                                    </span>
+                                  </ClickCatcher>
                                 </div>
                                 <div
                                   data-stylename="isnt-member"

--- a/src/components/Widget/JoinWidget/Join.scss
+++ b/src/components/Widget/JoinWidget/Join.scss
@@ -304,7 +304,6 @@
 .groupDescription {
   color: $color-regent;
   font-size: 14px;
-  white-space: pre-wrap;
   margin-bottom: 18px;
 }
 

--- a/src/components/Widget/RichTextWidget/RichTextWidget.js
+++ b/src/components/Widget/RichTextWidget/RichTextWidget.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import GroupAboutVideoEmbed from 'components/GroupAboutVideoEmbed'
+import ClickCatcher from 'components/ClickCatcher'
 import HyloHTML from 'components/HyloHTML'
 import './RichText.scss'
 
@@ -9,7 +10,9 @@ export default function RichTextWidget ({ group, settings }) {
       <GroupAboutVideoEmbed uri={settings.embeddedVideoURI} />
       <h2>{settings.title || `Welcome to ${group.name}!`}</h2>
       {settings.richText && (
-        <HyloHTML element='span' html={settings.richText} />
+        <ClickCatcher groupSlug='all'>
+          <HyloHTML element='span' html={settings.richText} />
+        </ClickCatcher>
       )}
       {settings.text && (
         <p>{settings.text}</p>

--- a/src/components/Widget/RichTextWidget/RichTextWidget.js
+++ b/src/components/Widget/RichTextWidget/RichTextWidget.js
@@ -10,7 +10,7 @@ export default function RichTextWidget ({ group, settings }) {
       <GroupAboutVideoEmbed uri={settings.embeddedVideoURI} />
       <h2>{settings.title || `Welcome to ${group.name}!`}</h2>
       {settings.richText && (
-        <ClickCatcher groupSlug='all'>
+        <ClickCatcher>
           <HyloHTML element='span' html={settings.richText} />
         </ClickCatcher>
       )}

--- a/src/components/Widget/WelcomeWidget/WelcomeWidget.js
+++ b/src/components/Widget/WelcomeWidget/WelcomeWidget.js
@@ -18,7 +18,7 @@ export default class WelcomeWidget extends Component {
     return (
       <div styleName='welcome-widget'>
         <h2>{settings.title || `Welcome to ${group.name}!`}</h2>
-        <ClickCatcher groupSlug='all'>
+        <ClickCatcher>
           <HyloHTML element='p' html={TextHelpers.markdown(message)} />
         </ClickCatcher>
       </div>

--- a/src/components/Widget/WelcomeWidget/WelcomeWidget.js
+++ b/src/components/Widget/WelcomeWidget/WelcomeWidget.js
@@ -1,6 +1,7 @@
 import { TextHelpers } from 'hylo-shared'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
+import ClickCatcher from 'components/ClickCatcher'
 import HyloHTML from 'components/HyloHTML'
 import './WelcomeWidget.scss'
 
@@ -17,7 +18,9 @@ export default class WelcomeWidget extends Component {
     return (
       <div styleName='welcome-widget'>
         <h2>{settings.title || `Welcome to ${group.name}!`}</h2>
-        <HyloHTML element='p' html={TextHelpers.markdown(message)} />
+        <ClickCatcher groupSlug='all'>
+          <HyloHTML element='p' html={TextHelpers.markdown(message)} />
+        </ClickCatcher>
       </div>
     )
   }

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types'
 import { TextHelpers, WebViewMessageTypes } from 'hylo-shared'
 import isWebView, { sendMessageToWebView } from 'util/webView'
 import Avatar from 'components/Avatar'
+import ClickCatcher from 'components/ClickCatcher'
 import FarmGroupDetailBody from 'components/FarmGroupDetailBody'
 import GroupAboutVideoEmbed from 'components/GroupAboutVideoEmbed'
 import HyloHTML from 'components/HyloHTML'
@@ -197,7 +198,9 @@ export class UnwrappedGroupDetail extends Component {
           ) : (
             <div styleName='g.groupDescription'>
               <GroupAboutVideoEmbed uri={group.aboutVideoUri} styleName='g.groupAboutVideo' />
-              <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
+              <ClickCatcher groupSlug='all'>
+                <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
+              </ClickCatcher>
             </div>
           )}
         {!isAboutCurrentGroup && topics && topics.length && (

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -186,6 +186,9 @@ export class UnwrappedGroupDetail extends Component {
 
     return (
       <>
+        {isAboutCurrentGroup && group.aboutVideoUri && (
+          <GroupAboutVideoEmbed uri={group.aboutVideoUri} styleName='g.groupAboutVideo' />
+        )}
         {isAboutCurrentGroup && !group.description && canModerate
           ? (
             <div styleName='g.no-description'>
@@ -197,7 +200,6 @@ export class UnwrappedGroupDetail extends Component {
             </div>
           ) : (
             <div styleName='g.groupDescription'>
-              <GroupAboutVideoEmbed uri={group.aboutVideoUri} styleName='g.groupAboutVideo' />
               <ClickCatcher groupSlug='all'>
                 <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
               </ClickCatcher>

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -200,7 +200,7 @@ export class UnwrappedGroupDetail extends Component {
             </div>
           ) : (
             <div styleName='g.groupDescription'>
-              <ClickCatcher groupSlug='all'>
+              <ClickCatcher>
                 <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
               </ClickCatcher>
             </div>

--- a/src/routes/GroupDetail/GroupDetail.scss
+++ b/src/routes/GroupDetail/GroupDetail.scss
@@ -304,7 +304,6 @@
 .groupDescription {
   color: $color-regent;
   font-size: 14px;
-  white-space: pre-wrap;
   margin-bottom: 18px;
 }
 

--- a/src/routes/GroupSidebar/GroupSidebar.js
+++ b/src/routes/GroupSidebar/GroupSidebar.js
@@ -76,7 +76,7 @@ export class AboutSection extends Component {
       </div>
       <div styleName={cx('description', { expanded })}>
         {!expanded && <div styleName='gradient' />}
-        <ClickCatcher groupSlug='all'>
+        <ClickCatcher>
           <HyloHTML element='span' html={TextHelpers.markdown(description)} />
         </ClickCatcher>
       </div>

--- a/src/routes/GroupSidebar/GroupSidebar.js
+++ b/src/routes/GroupSidebar/GroupSidebar.js
@@ -5,6 +5,7 @@ import { isEmpty } from 'lodash/fp'
 import { TextHelpers } from 'hylo-shared'
 import { personUrl, groupUrl } from 'util/navigation'
 import Avatar from 'components/Avatar'
+import ClickCatcher from 'components/ClickCatcher'
 import Loading from 'components/Loading'
 import RoundImageRow from 'components/RoundImageRow'
 import Button from 'components/Button'
@@ -75,7 +76,9 @@ export class AboutSection extends Component {
       </div>
       <div styleName={cx('description', { expanded })}>
         {!expanded && <div styleName='gradient' />}
-        <HyloHTML element='span' html={TextHelpers.markdown(description)} />
+        <ClickCatcher groupSlug='all'>
+          <HyloHTML element='span' html={TextHelpers.markdown(description)} />
+        </ClickCatcher>
       </div>
       {showExpandButton && <span styleName='expand-button' onClick={onClick}>
         {expanded ? 'Show Less' : 'Read More'}

--- a/src/routes/Groups/Groups.js
+++ b/src/routes/Groups/Groups.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import React, { Component } from 'react'
 import { TextHelpers } from 'hylo-shared'
+import ClickCatcher from 'components/ClickCatcher'
 import Icon from 'components/Icon'
 import RoundImage from 'components/RoundImage'
 import GroupNetworkMap from 'components/GroupNetworkMap'
@@ -112,7 +113,9 @@ export function GroupCard ({ group, routeParams }) {
             </div>
           </div>
           <div styleName='group-description'>
-            <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
+            <ClickCatcher groupSlug='all'>
+              <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
+            </ClickCatcher>
           </div>
         </div>
       </div>

--- a/src/routes/Groups/Groups.js
+++ b/src/routes/Groups/Groups.js
@@ -113,7 +113,7 @@ export function GroupCard ({ group, routeParams }) {
             </div>
           </div>
           <div styleName='group-description'>
-            <ClickCatcher groupSlug='all'>
+            <ClickCatcher>
               <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
             </ClickCatcher>
           </div>

--- a/src/routes/Messages/Message/Message.js
+++ b/src/routes/Messages/Message/Message.js
@@ -30,7 +30,7 @@ export default function Message ({ message, isHeader }) {
           <span styleName='date'>{pending ? 'sending...' : TextHelpers.humanDate(message.createdAt)}</span>
         </div>}
         <div styleName='text'>
-          <ClickCatcher groupSlug='all'>
+          <ClickCatcher>
             <HyloHTML element='span' html={text} />
           </ClickCatcher>
         </div>

--- a/src/routes/Messages/Message/Message.js
+++ b/src/routes/Messages/Message/Message.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import cx from 'classnames'
 import Avatar from 'components/Avatar'
+import ClickCatcher from 'components/ClickCatcher'
 import HyloHTML from 'components/HyloHTML'
 import { personUrl } from 'util/navigation'
 import { TextHelpers } from 'hylo-shared'
@@ -29,7 +30,9 @@ export default function Message ({ message, isHeader }) {
           <span styleName='date'>{pending ? 'sending...' : TextHelpers.humanDate(message.createdAt)}</span>
         </div>}
         <div styleName='text'>
-          <HyloHTML element='span' html={text} />
+          <ClickCatcher groupSlug='all'>
+            <HyloHTML element='span' html={text} />
+          </ClickCatcher>
         </div>
       </div>
     </div>

--- a/src/routes/Messages/Message/__snapshots__/Message.test.js.snap
+++ b/src/routes/Messages/Message/__snapshots__/Message.test.js.snap
@@ -31,10 +31,14 @@ exports[`to display sending... when message is still in optimistic state 1`] = `
     <div
       data-stylename="text"
     >
-      <HyloHTML
-        element="span"
-        html="sending..."
-      />
+      <ClickCatcher
+        groupSlug="all"
+      >
+        <HyloHTML
+          element="span"
+          html="sending..."
+        />
+      </ClickCatcher>
     </div>
   </div>
 </div>
@@ -54,11 +58,15 @@ exports[`to match the latest non-header snapshot 1`] = `
     <div
       data-stylename="text"
     >
-      <HyloHTML
-        element="span"
-        html="<p>test</p>
+      <ClickCatcher
+        groupSlug="all"
+      >
+        <HyloHTML
+          element="span"
+          html="<p>test</p>
 "
-      />
+        />
+      </ClickCatcher>
     </div>
   </div>
 </div>
@@ -93,11 +101,15 @@ exports[`to match the latest snapshot 1`] = `
     <div
       data-stylename="text"
     >
-      <HyloHTML
-        element="span"
-        html="<p>test</p>
+      <ClickCatcher
+        groupSlug="all"
+      >
+        <HyloHTML
+          element="span"
+          html="<p>test</p>
 "
-      />
+        />
+      </ClickCatcher>
     </div>
   </div>
 </div>

--- a/src/routes/Messages/Message/__snapshots__/Message.test.js.snap
+++ b/src/routes/Messages/Message/__snapshots__/Message.test.js.snap
@@ -31,9 +31,7 @@ exports[`to display sending... when message is still in optimistic state 1`] = `
     <div
       data-stylename="text"
     >
-      <ClickCatcher
-        groupSlug="all"
-      >
+      <ClickCatcher>
         <HyloHTML
           element="span"
           html="sending..."
@@ -58,9 +56,7 @@ exports[`to match the latest non-header snapshot 1`] = `
     <div
       data-stylename="text"
     >
-      <ClickCatcher
-        groupSlug="all"
-      >
+      <ClickCatcher>
         <HyloHTML
           element="span"
           html="<p>test</p>
@@ -101,9 +97,7 @@ exports[`to match the latest snapshot 1`] = `
     <div
       data-stylename="text"
     >
-      <ClickCatcher
-        groupSlug="all"
-      >
+      <ClickCatcher>
         <HyloHTML
           element="span"
           html="<p>test</p>

--- a/src/routes/Messages/MessageSection/MessageSection.js
+++ b/src/routes/Messages/MessageSection/MessageSection.js
@@ -153,7 +153,7 @@ export default class MessageSection extends React.Component {
       {pending && <Loading />}
       {!pending &&
         <div styleName='messages-section-inner'>
-          <ClickCatcher groupSlug='all'>
+          <ClickCatcher>
             {createMessageList(messages, lastSeenAtTimes[get('id', messageThread)])}
           </ClickCatcher>
         </div>

--- a/src/routes/Messages/MessageSection/MessageSection.js
+++ b/src/routes/Messages/MessageSection/MessageSection.js
@@ -4,6 +4,7 @@ import { throttle, debounce } from 'lodash'
 import { get } from 'lodash/fp'
 import Loading from 'components/Loading'
 import Message from '../Message'
+import ClickCatcher from 'components/ClickCatcher'
 import './MessageSection.scss'
 
 // the maximum amount of time in minutes that can pass between messages to still
@@ -152,7 +153,9 @@ export default class MessageSection extends React.Component {
       {pending && <Loading />}
       {!pending &&
         <div styleName='messages-section-inner'>
-          {createMessageList(messages, lastSeenAtTimes[get('id', messageThread)])}
+          <ClickCatcher groupSlug='all'>
+            {createMessageList(messages, lastSeenAtTimes[get('id', messageThread)])}
+          </ClickCatcher>
         </div>
       }
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9497,15 +9497,15 @@ husky@^7.0.4:
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
   integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
 
-hylo-shared@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/hylo-shared/-/hylo-shared-5.0.0.tgz#7cc76a87d092947b9c78aafb270e059d29866e41"
-  integrity sha512-72wTvmE1VfZEZ6Hk6jdrmXz4ocF66Y6FkHFDjqRwO9KYe5FSRwOY9tImperx12sB8GZY+Ss1R8sn0JF8IhOyyA==
+hylo-shared@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/hylo-shared/-/hylo-shared-5.1.0.tgz#e4cdb43a2d65926d195bb70e6a24b874efc03f52"
+  integrity sha512-YWXEs8F/Sw6yazUi6Nii8JMoLa9P5HfnUJ8B+JcyZNs3EaDbf04FVZdi1bFYMgzcl+uNNx9ebRWY+2mJPGRqoQ==
   dependencies:
     coordinate-parser "^1.0.7"
     html-to-text "^8.1.0"
     lodash "~4.17.21"
-    marked "^4.0.12"
+    marked "^4.2.1"
     pretty-date "^0.2.0"
     querystring "^0.2.1"
     trunc-html "^1.1.2"
@@ -11788,10 +11788,10 @@ mapbox-gl@^2.3.0, mapbox-gl@^2.7.1:
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.3"
 
-marked@^4.0.12:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.1.1.tgz#2f709a4462abf65a283f2453dc1c42ab177d302e"
-  integrity sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==
+marked@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.1.tgz#eaa32594e45b4e58c02e4d118531fd04345de3b4"
+  integrity sha512-VK1/jNtwqDLvPktNpL0Fdg3qoeUZhmRsuiIjPEy/lHwXW4ouLoZfO4XoWd4ClDt+hupV1VLpkZhEovjU0W/kqA==
 
 math-random@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
This will give proper formatting back to Group Descriptions as well as linking. 

* Also applies `ClickCatch` wherever markdown is used currently (so also on Message#text), as with `autolinking` on that is needed to keep folks from navigating away from Hylo when they click in links in those other contexts, as well as to keep Hylo links staying on the site. 

* Not required, but would be best to merge the backend Hylo-shared nudge soon so there isn't drift: https://github.com/Hylozoic/hylo-node/pull/886