### PR TITLE
1358 - Remove CSS `:hover` selector color on non-hover devices (mobile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Styling of `groupDescription` to eliminate extra vertical space between paragraphs
 - Back button behavior in the case of `LandingPage` > "About Us"
+- Unexpected underline appearing in some links in mobile
+- Sticking hover state color on MapExplorer buttons in mobile
 
 ### Changed
 - Added default of `all` to `groupSlug` prop of `ClickCatcher`, doesn't change current behavior

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -34,8 +34,10 @@
   border: 1px solid $color-caribbean-green;
   background-color: $color-caribbean-green;
   color: $color-white;
-  &:hover, &.hover {
-    background-color: lighten($color-caribbean-green, 2%);
+  @media (hover: hover) and (pointer: fine) {
+    &:hover, &.hover {
+      background-color: lighten($color-caribbean-green, 2%);
+    }
   }
   &:active, &.active {
     background-color: darken($color-caribbean-green, 2%);
@@ -49,8 +51,10 @@
 .purple {
   background-color: $color-medium-purple;
   color: $color-white;
-  &:hover, &.hover {
-    background-color: lighten($color-medium-purple, 3%);
+  @media (hover: hover) and (pointer: fine) {
+    &:hover, &.hover {
+      background-color: lighten($color-medium-purple, 3%);
+    }
   }
   &:active, &.active {
     background-color: darken($color-medium-purple, 3%);
@@ -61,9 +65,11 @@
   color: $color-caribbean-green;
   background-color: $color-white;
   border: 1px solid $color-alto;
-  &:hover, &.hover {
-    background-color: $color-polar;
-    border-color: $color-caribbean-green;
+  @media (hover: hover) and (pointer: fine) {
+    &:hover, &.hover {
+      background-color: $color-polar;
+      border-color: $color-caribbean-green;
+    }
   }
   &:active, &.active {
     background-color: $color-ziggurat;
@@ -85,8 +91,10 @@
   border: 1px solid $color-regent;
   background-color: $color-regent;
   color: $color-white;
-  &:hover, &.hover {
-    background-color: lighten($color-regent, 2%);
+  @media (hover: hover) and (pointer: fine) {
+    &:hover, &.hover {
+      background-color: lighten($color-regent, 2%);
+    }
   }
   &:active, &.active {
     background-color: darken($color-regent, 2%);
@@ -101,8 +109,10 @@
   border: 1px solid $color-regent;
   background-color: $color-white;
   color: $color-regent;
-  &:hover, &.hover {
-    background-color: lighten($color-white, 2%);
+  @media (hover: hover) and (pointer: fine) {
+    &:hover, &.hover {
+      background-color: lighten($color-white, 2%);
+    }
   }
   &:active, &.active {
     background-color: darken($color-white, 2%);

--- a/src/components/CreateModal/CreateModal.scss
+++ b/src/components/CreateModal/CreateModal.scss
@@ -165,23 +165,24 @@
         }
       }
     }
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        text-decoration: none;
 
-    &:hover {
-      text-decoration: none;
+        div {
+          background-color: rgba(208,240,234,1);
 
-      div {
-        background-color: rgba(208,240,234,1);
+          .indicator {
+            background-color: rgba(0, 196, 159, 1.00);
+          }
 
-        .indicator {
-          background-color: rgba(0, 196, 159, 1.00);
-        }
+          .postTypeDescription {
+            color: rgba(128,140,155,1);
+          }
 
-        .postTypeDescription {
-          color: rgba(128,140,155,1);
-        }
-
-        .postIcon:before {
-          color: rgba(13, 195, 159, 1);
+          .postIcon:before {
+            color: rgba(13, 195, 159, 1);
+          }
         }
       }
     }

--- a/src/components/CreateModal/CreateModalChooser.js
+++ b/src/components/CreateModal/CreateModalChooser.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import Icon from 'components/Icon'
+import isWebView from 'util/webView'
 import { POST_TYPES } from 'store/models/Post'
+import Icon from 'components/Icon'
 import './CreateModal.scss'
 
 const postTypes = Object.keys(POST_TYPES)
@@ -33,16 +34,19 @@ export default function CreateModalChooser ({ location }) {
           </Link>
         )
       })}
-      <Link to={`${location.pathname}/group`}>
-        <div key='group'>
-          <Icon name='Groups' styleName='postIcon' />
-          <b>
-            <span styleName='postTypeName'>Group</span>
-            <span styleName='postTypeDescription'>Create a new movement, network, community or group!</span>
-          </b>
-          <span styleName='indicator' />
-        </div>
-      </Link>
+      {/* Creating a Group by location is not currently supported in HyloApp */}
+      {!isWebView() && (
+        <Link to={`${location.pathname}/group`}>
+          <div key='group'>
+            <Icon name='Groups' styleName='postIcon' />
+            <b>
+              <span styleName='postTypeName'>Group</span>
+              <span styleName='postTypeDescription'>Create a new movement, network, community or group!</span>
+            </b>
+            <span styleName='indicator' />
+          </div>
+        </Link>
+      )}
     </div>
   )
 }

--- a/src/css/typography.scss
+++ b/src/css/typography.scss
@@ -61,6 +61,26 @@ a {
   }
 }
 
+/* 
+NOTE: There is an issue of an underline appearing under some
+links in mobile, but I've only see it happen in mobile/non-hover
+devices. We don't apparently globally turn-off the browser default
+`text-decoration: underline` here, and it may be that bootstrap
+doesn't turn that off by default either. Doing a global search
+reveals an unusual amount of `text-decoration: none` for link
+styles, which leads me to believe it is not globally turned-off
+and that maybe we should, and remove some of the extra attributes
+down the line.
+
+Forcing the fix here, and probably save to do this
+outside the media query, but leaving it at this for now.
+*/
+@media (hover: none) {
+  a {
+    text-decoration: none !important; 
+  }
+}
+
 a.hylo-link,
 .mention,
 .topic

--- a/src/css/typography.scss
+++ b/src/css/typography.scss
@@ -54,9 +54,11 @@ a {
   color: #0275d8
 }
 
-a:focus,
-a:hover {
-  color: #014c8c
+@media (hover: hover) and (pointer: fine) {
+  a:focus,
+  a:hover {
+    color: #014c8c
+  }
 }
 
 a.hylo-link,
@@ -65,9 +67,11 @@ a.hylo-link,
 {
   color: $color-caribbean-green;
   cursor: pointer;
-  &:hover {
-    text-decoration: none;
-    color: $color-gossamer;
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      text-decoration: none;
+      color: $color-gossamer;
+    }
   }
 }
 
@@ -203,10 +207,12 @@ textarea {
   font-size: 14px;
   letter-spacing: 0;
   line-height: 20px;
-  &:hover {
-    text-decoration: none;
-    color: $color-gossamer;
-    cursor: pointer;
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      text-decoration: none;
+      color: $color-gossamer;
+      cursor: pointer;
+    }
   }
 }
 
@@ -216,9 +222,11 @@ textarea {
   font-size: 10px;
   letter-spacing: 0.6;
   line-height: 14px;
-  &:hover {
-    color: $color-gossamer;
-    cursor: pointer;
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      color: $color-gossamer;
+      cursor: pointer;
+    }
   }
 }
 

--- a/src/routes/MapExplorer/MapExplorer.scss
+++ b/src/routes/MapExplorer/MapExplorer.scss
@@ -219,11 +219,21 @@ button.toggleFeatureFiltersButton {
   box-shadow: $box-shadow-default;
   padding: 8px;
 
-  &.open, &:hover {
+  &.open {
     background-color: $color-caribbean-green;
 
     span {
       color: white;
+    }
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: $color-caribbean-green;
+
+      span {
+        color: white;
+      }
     }
   }
 }
@@ -357,9 +367,6 @@ button.toggleFeatureFiltersButton {
     cursor: pointer;  
   }
 
-  // Necessary to keep simulated hover event on touch devices
-  // from sticking (Saved Search button was remaining
-  // highlighted after closed)
   @media (hover: hover) and (pointer: fine) {
     &:hover {
       background-color: $color-caribbean-green;
@@ -372,12 +379,13 @@ button.toggleFeatureFiltersButton {
 .addItemToMapButton {
   bottom: 40px;
   padding: 8px;
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: $color-caribbean-green;
 
-  &:hover {
-    background-color: $color-caribbean-green;
-
-    span {
-      color: white;
+      span {
+        color: white;
+      }
     }
   }
 


### PR DESCRIPTION
This makes the MapExplorer buttons not get stuck in hover state color in App / mobile. Would be nice to get it in out for this release.