### PR TITLE
Moves locationObject to "general text" code into shared

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "html-webpack-plugin": "^4.5.1",
     "http-proxy-middleware": "0.17.4",
     "husky": "^7.0.4",
-    "hylo-shared": "5.1.0",
+    "hylo-shared": "5.1.2",
     "identity-obj-proxy": "3.0.0",
     "immutability-helper": "^3.1.1",
     "immutable": "~3.7.4",

--- a/src/components/PostCard/PostTitle/PostTitle.js
+++ b/src/components/PostCard/PostTitle/PostTitle.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { LocationHelpers } from 'hylo-shared'
 import Highlight from 'components/Highlight'
 import cx from 'classnames'
 import Icon from 'components/Icon'
@@ -12,18 +13,7 @@ export default function PostTitle ({
   location
 }) {
   // Formatting location to display in stream view
-  let generalLocation = location || ''
-  if (locationObject) {
-    if (locationObject.addressNumber) {
-      generalLocation = `${locationObject.addressNumber} ${locationObject.addressStreet}, ${locationObject.city}, ${locationObject.region}`
-    } else if (locationObject.city) {
-      generalLocation = `${locationObject.city}, ${locationObject.region}`
-    } else if (locationObject.fullText) {
-      generalLocation = locationObject.fullText
-    } else if (locationObject.center) {
-      generalLocation = `${locationObject.center.lat}, ${locationObject.center.lng}`
-    }
-  }
+  const generalLocation = LocationHelpers.generalLocationString(locationObject, location || '')
 
   return <Highlight {...highlightProps}>
     <React.Fragment>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9497,10 +9497,10 @@ husky@^7.0.4:
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
   integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
 
-hylo-shared@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/hylo-shared/-/hylo-shared-5.1.0.tgz#e4cdb43a2d65926d195bb70e6a24b874efc03f52"
-  integrity sha512-YWXEs8F/Sw6yazUi6Nii8JMoLa9P5HfnUJ8B+JcyZNs3EaDbf04FVZdi1bFYMgzcl+uNNx9ebRWY+2mJPGRqoQ==
+hylo-shared@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/hylo-shared/-/hylo-shared-5.1.2.tgz#b68c48ca7ef8bbe8a0208443a4bc732712438de1"
+  integrity sha512-kWfhzWHg9Yu6v5ZtnejkMxAFglnPxTXLT2Ejb2y8Bbij1u8TQoOF3qTSNbJW+iEtZpGahCfMxG/RRK3BWrteHQ==
   dependencies:
     coordinate-parser "^1.0.7"
     html-to-text "^8.1.0"


### PR DESCRIPTION
Updating PostCard in the App and needed this. Behavior is same as before on Web, and have tested. Don't think it deserves a CHANGELOG note.

Can see implementation here: https://github.com/Hylozoic/hylo-shared/blob/9848278a9f3d734c59561a8ed7512f83c7a095cf/src/LocationHelpers.js#L79