### PR TITLE
Fixes Mobile editor with Topic or Mention selection editor height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Hylo Evo (the Hylo front-end) will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- `CommentEditor` in HyloApp not expanding height after selecting Mention or Topic (HyloReactNative #614)
+
 ## [5.0.3] - 2022-11-16
 
 ### Added

--- a/src/components/HyloEditor/HyloEditor.scss
+++ b/src/components/HyloEditor/HyloEditor.scss
@@ -75,6 +75,9 @@
 // Mention and Topic suggestions
 // * see HyloEditorMobile.scss for Mobile theme of same
 :global {
+  .ProseMirror.suggestion-list-padding {
+    padding-bottom: 1.7rem;
+  }
   .tippy-box[data-theme='suggestions'] {
     background-color: transparent;
     

--- a/src/components/HyloEditor/HyloEditor.scss
+++ b/src/components/HyloEditor/HyloEditor.scss
@@ -75,9 +75,6 @@
 // Mention and Topic suggestions
 // * see HyloEditorMobile.scss for Mobile theme of same
 :global {
-  .ProseMirror.suggestion-list-padding {
-    padding-bottom: 1.7rem;
-  }
   .tippy-box[data-theme='suggestions'] {
     background-color: transparent;
     

--- a/src/components/HyloEditor/HyloEditorMobile.scss
+++ b/src/components/HyloEditor/HyloEditorMobile.scss
@@ -1,4 +1,8 @@
 :global {
+  .ProseMirror.suggestion-list-padding {
+    padding-bottom: 1.7rem;
+  }
+
   // Mention and Topic suggestions
   .tippy-box[data-theme='suggestions-mobile'] {
     background-color: transparent;

--- a/src/components/HyloEditor/extensions/suggestions/index.js
+++ b/src/components/HyloEditor/extensions/suggestions/index.js
@@ -24,30 +24,24 @@ export default {
 
       if (suggestionsThemeName === 'suggestions-mobile') {
         // This handles the case of the Mobile Editor being in a container that is not
-        // tall enought to accomodate suggestions. Adds padding while suggesting, removes
+        // tall enough to accommodate suggestions. Adds padding while suggesting, removes
         // it on cancel or when a selection has been made.
         return tippy('body', {
           ...tippyOptions,
           onShown: () => {
-            const suggestionsRoot = document.querySelector('[data-tippy-root]')
-            const suggestionsHeight = parseInt(window.getComputedStyle(suggestionsRoot).height) || 0
+            const suggestionsElement = document.querySelector('[data-tippy-root]')
+            const suggestionsHeight = parseInt(window.getComputedStyle(suggestionsElement).height) || 0
             const proseMirrorElement = document.querySelector('.ProseMirror')
             const proseMirrorElementHeight = parseInt(window.getComputedStyle(proseMirrorElement).height)
 
             if (proseMirrorElementHeight < (suggestionsHeight + 50)) {
-              const currentPaddingBottom = parseInt(proseMirrorElement.style.paddingBottom) || 0
-
-              window.hyloEditorPaddingBottomOriginal = currentPaddingBottom
-              proseMirrorElement.style.paddingBottom = currentPaddingBottom + suggestionsHeight + 'px'
+              proseMirrorElement.classList.add('suggestion-list-padding')
             }
           },
           onHide: () => {
-            if (
-              typeof window.hyloEditorPaddingBottomOriginal !== 'undefined' &&
-              window.hyloEditorPaddingBottomOriginal !== null
-            ) {
-              document.querySelector('.ProseMirror').style.paddingBottom = window.hyloEditorPaddingBottomOriginal + 'px'
-            }
+            const proseMirrorElement = document.querySelector('.ProseMirror')
+
+            proseMirrorElement.classList.remove('suggestion-list-padding')
           }
         })
       }


### PR DESCRIPTION
Fixes Mobile editor with Topic or Mention selection when editor is sh…orter than the suggestions element. Fixes [Comment Editor not expanding height after selecting Mention or Topic](https://github.com/Hylozoic/HyloReactNative/issues/614)