### PR TITLE
Fix some routing issues when not logged in

### DIFF
--- a/src/routes/GroupSettings/ModeratorsSettingsTab/__snapshots__/ModeratorsSettingsTab.test.js.snap
+++ b/src/routes/GroupSettings/ModeratorsSettingsTab/__snapshots__/ModeratorsSettingsTab.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`AddModerator renders correctly when adding with suggestions 1`] = `
 <div
-  data-stylename="styles.add-moderator styles.adding"
+  data-stylename="styles.adding"
 >
   <div
     data-stylename="styles.help-text"
@@ -65,7 +65,7 @@ exports[`AddModerator renders correctly when adding with suggestions 1`] = `
 
 exports[`AddModerator renders correctly, and transitions from not adding to adding 1`] = `
 <div
-  data-stylename="styles.add-moderator styles.add-new"
+  data-stylename="styles.add-new"
   onClick={[Function]}
 >
   + Add New
@@ -74,7 +74,7 @@ exports[`AddModerator renders correctly, and transitions from not adding to addi
 
 exports[`AddModerator renders correctly, and transitions from not adding to adding 2`] = `
 <div
-  data-stylename="styles.add-moderator styles.adding"
+  data-stylename="styles.adding"
 >
   <div
     data-stylename="styles.help-text"
@@ -189,12 +189,12 @@ exports[`ModeratorsSettingsTab renders a list of RemovableListItems and AddModer
   </SettingsSection>
   <SettingsSection>
     <h3>
-      Roles & Badges
+      Other Roles & Badges
     </h3>
     <div
       data-stylename="styles.help-text"
     >
-      Create roles/badges for the group
+      Create additional roles or badges for the group
     </div>
     <div
       data-stylename="styles.add-role"

--- a/src/routes/PublicLayoutRouter/PublicLayoutRouter.js
+++ b/src/routes/PublicLayoutRouter/PublicLayoutRouter.js
@@ -26,11 +26,11 @@ export default function PublicLayoutRouter (props) {
       <PublicPageHeader />
       <Switch>
         <Route path={`/${POST_DETAIL_MATCH}`} exact component={PublicPostDetail} />
-        <Route path='/:context(groups)/:groupSlug' exact component={PublicGroupDetail} />
+        <Route path='/:context(groups)/:groupSlug' component={PublicGroupDetail} />
         <Route path='/:context(public)/:view(map)' component={MapExplorerLayoutRouter} />
         <Route path='/:context(public)/:view(groups)' component={GroupExplorerLayoutRouter} />
         <Redirect from={`(.*)/${POST_DETAIL_MATCH}`} to='/post/:postId' />
-        <Redirect to={{ pathname: '/public/map', state: { from: location } }} />
+        <Redirect to={{ pathname: '/login', state: { from: location } }} />
       </Switch>
       <HyloCookieConsent />
     </Div100vh>
@@ -41,6 +41,7 @@ export function PublicGroupDetail (props) {
   const dispatch = useDispatch()
   const routeParams = useParams()
   const history = useHistory()
+  const location = useLocation()
   const [loading, setLoading] = useState(true)
   const groupSlug = routeParams?.groupSlug
 
@@ -51,7 +52,7 @@ export function PublicGroupDetail (props) {
       const result = await dispatch(checkIsPublicGroup(groupSlug))
       const isPublicGroup = result?.payload?.data?.group?.visibility === 2
       if (!isPublicGroup) {
-        history.replace('/login')
+        history.replace('/login?returnToUrl=' + location.pathname + location.search)
       }
 
       setLoading(false)
@@ -73,6 +74,7 @@ export function PublicPostDetail (props) {
   const dispatch = useDispatch()
   const routeParams = useParams()
   const history = useHistory()
+  const location = useLocation()
   const [loading, setLoading] = useState(true)
   const postId = routeParams?.postId
 
@@ -84,7 +86,7 @@ export function PublicPostDetail (props) {
       const isPublicPost = result?.payload?.data?.post?.id
 
       if (!isPublicPost) {
-        history.replace('/login')
+        history.replace('/login?returnToUrl=' + location.pathname + location.search)
       }
 
       setLoading(false)


### PR DESCRIPTION
When viewing a /groups... page either show the public groups page for public groups or redirect to login, instead of redirecting to the public map

When redirecting to /login for non public group or post make sure to include correct returnToUrl