### PR TITLE
Odds and ends

### DIFF
--- a/src/components/SkillsSection/SkillsSection.store.js
+++ b/src/components/SkillsSection/SkillsSection.store.js
@@ -115,7 +115,7 @@ export function fetchMemberSkills (id, limit = 20) {
   return {
     type: FETCH_MEMBER_SKILLS,
     graphql: {
-      query: `query ($id: ID, $limit: Int) {
+      query: `query MemberSkills ($id: ID, $limit: Int) {
         person (id: $id) {
           id
           skills (first: $limit) {

--- a/src/components/SkillsToLearnSection/SkillsToLearnSection.store.js
+++ b/src/components/SkillsToLearnSection/SkillsToLearnSection.store.js
@@ -66,7 +66,7 @@ export function fetchMemberSkills (id, limit = 20) {
   return {
     type: FETCH_MEMBER_SKILLS,
     graphql: {
-      query: `query ($id: ID, $limit: Int) {
+      query: `query MemberSkillsToLearn ($id: ID, $limit: Int) {
         person (id: $id) {
           id
           skillsToLearn (first: $limit) {

--- a/src/graphql/fragments/postFieldsFragment.js
+++ b/src/graphql/fragments/postFieldsFragment.js
@@ -159,8 +159,6 @@ const postFieldsFragment = withComments => `
   topics {
     id
     name
-    postsTotal
-    followersTotal
   }
   members {
     total

--- a/src/routes/AuthLayoutRouter/AuthLayoutRouter.js
+++ b/src/routes/AuthLayoutRouter/AuthLayoutRouter.js
@@ -219,6 +219,9 @@ export default function AuthLayoutRouter (props) {
       <Helmet>
         <title>{currentGroup ? `${currentGroup.name} | ` : ''}Hylo</title>
         <meta name='description' content='Prosocial Coordination for a Thriving Planet' />
+        <script id='greencheck' type='application/json'>
+          {`{ id: "${currentUser.id}", fullname: "${currentUser.name}", description: "${currentUser.tagline}", image: "${currentUser.avatarUrl}" }`}
+        </script>
       </Helmet>
       {/* Redirects for switching into global contexts, since these pages don't exist yet */}
       <RedirectRoute exact path='/:context(public)/(members|settings)' to='/public' />

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -210,24 +210,26 @@ class UnwrappedGroupDetail extends Component {
               <Link to={groupUrl(group.slug, 'settings')}>{t('Add a group description')}</Link>
             </div>
           </div>
-          : <div styleName='g.groupDescription'>
-            {group.purpose
-              ? <>
-                <h3>{t('Purpose')}</h3>
-                <ClickCatcher>
-                  <HyloHTML element='span' html={TextHelpers.markdown(group.purpose)} />
-                </ClickCatcher>
-              </>
-              : ''}
-            {group.description
-              ? <>
-                <h3>{t('Description')}</h3>
-                <ClickCatcher>
-                  <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
-                </ClickCatcher>
-              </>
-              : ''}
-          </div>
+          : group.purpose || group.description
+            ? <div styleName={cx('g.groupDescription')}>
+              {group.purpose
+                ? <>
+                  <h3>{t('Purpose')}</h3>
+                  <ClickCatcher>
+                    <HyloHTML element='span' html={TextHelpers.markdown(group.purpose)} />
+                  </ClickCatcher>
+                </>
+                : ''}
+              {group.description
+                ? <>
+                  <h3>{t('Description')}</h3>
+                  <ClickCatcher>
+                    <HyloHTML element='span' html={TextHelpers.markdown(group.description)} />
+                  </ClickCatcher>
+                </>
+                : ''}
+            </div>
+          : ''
         }
         {/* XXX: turning this off for now because topics are random and can be weird. Turn back on when groups have their own #tags
         {!isAboutCurrentGroup && topics && topics.length && (

--- a/src/routes/GroupDetail/GroupDetail.js
+++ b/src/routes/GroupDetail/GroupDetail.js
@@ -229,7 +229,7 @@ class UnwrappedGroupDetail extends Component {
                 </>
                 : ''}
             </div>
-          : ''
+            : ''
         }
         {/* XXX: turning this off for now because topics are random and can be weird. Turn back on when groups have their own #tags
         {!isAboutCurrentGroup && topics && topics.length && (

--- a/src/routes/MapExplorer/__snapshots__/MapExplorer.store.test.js.snap
+++ b/src/routes/MapExplorer/__snapshots__/MapExplorer.store.test.js.snap
@@ -311,8 +311,6 @@ posts: viewPosts(
   topics {
     id
     name
-    postsTotal
-    followersTotal
   }
   members {
     total

--- a/src/routes/MemberProfile/MemberProfile.js
+++ b/src/routes/MemberProfile/MemberProfile.js
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import React, { useState } from 'react'
 import { useTranslation, withTranslation } from 'react-i18next'
 import { filter, isFunction } from 'lodash'
@@ -5,7 +6,7 @@ import CopyToClipboard from 'react-copy-to-clipboard'
 import Moment from 'moment-timezone'
 import ReactTooltip from 'react-tooltip'
 import { Helmet } from 'react-helmet'
-import cx from 'classnames'
+import { TextHelpers } from 'hylo-shared'
 import { twitterUrl, AXOLOTL_ID } from 'store/models/Person'
 import { bgImageStyle } from 'util/index'
 import {
@@ -17,7 +18,9 @@ import {
 import Affiliation from 'components/Affiliation'
 import Button from 'components/Button'
 import BadgeEmoji from 'components/BadgeEmoji'
+import ClickCatcher from 'components/ClickCatcher'
 import Dropdown from 'components/Dropdown'
+import HyloHTML from 'components/HyloHTML'
 import Icon from 'components/Icon'
 import NotFound from 'components/NotFound'
 import RoundImage from 'components/RoundImage'
@@ -38,7 +41,7 @@ class MemberProfile extends React.Component {
     blockConfirmMessage: `Are you sure you want to block this member?
     You will no longer see this member's activity
     and they won't see yours.
-    
+
     You can unblock this member at any time.
     Go to Settings > Blocked Users.`
   }
@@ -154,7 +157,11 @@ class MemberProfile extends React.Component {
             <ActionDropdown items={actionDropdownItems} />
           </div>
           {person.tagline && <div styleName='tagline'>{person.tagline}</div>}
-          {person.bio && <div styleName='bio'>{person.bio}</div>}
+          {person.bio && <div styleName='bio'>
+            <ClickCatcher>
+              <HyloHTML element='span' html={TextHelpers.markdown(person.bio)} />
+            </ClickCatcher>
+          </div>}
           <div styleName='member-details'>
             <div styleName='profile-subhead'>
               {t('Skills & Interests')}

--- a/src/routes/MemberProfile/__snapshots__/MemberProfile.test.js.snap
+++ b/src/routes/MemberProfile/__snapshots__/MemberProfile.test.js.snap
@@ -126,7 +126,13 @@ exports[`MemberProfile renders the same as the last snapshot 1`] = `
     <div
       data-stylename="bio"
     >
-      I like wombats.
+      <ClickCatcher>
+        <HyloHTML
+          element="span"
+          html="<p>I like wombats.</p>
+"
+        />
+      </ClickCatcher>
     </div>
     <div
       data-stylename="member-details"

--- a/src/store/actions/__snapshots__/fetchPosts.test.js.snap
+++ b/src/store/actions/__snapshots__/fetchPosts.test.js.snap
@@ -160,8 +160,6 @@ posts: viewPosts(
   topics {
     id
     name
-    postsTotal
-    followersTotal
   }
   members {
     total
@@ -390,8 +388,6 @@ posts(
   topics {
     id
     name
-    postsTotal
-    followersTotal
   }
   members {
     total


### PR DESCRIPTION
- Add script tag to support CTA Project Greencheck https://greencheck.world
- Don't show blank box on group details if purpose and description both empty
- Support display of markdown for user profiles 
- Optimization: When loading post topics don't load topic.postsTotal and followersTotal. This should significantly speed up loading of posts in chat rooms, and across the app, and shouldn't cause any issues.