### PR TITLE
Evo 1585 add duplicate post option

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -207,6 +207,7 @@
   "Donation Link": "Donation Link",
   "Download App": "Download App",
   "Download our": "Download our",
+  "Duplicate": "Duplicate",
   "Ecosystem services": "Ecosystem services",
   "Edit": "Edit",
   "Edit Profile": "Edit Profile",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -206,6 +206,7 @@
   "Donation Link": "Enlace de donación",
   "Download App": "Descargar aplicación",
   "Download our": "Descarga nuestro",
+  "Duplicate": "Duplicar",
   "Ecosystem services": "Servicios de ecosistema",
   "Edit": "Editar",
   "Edit Profile": "Editar perfil",

--- a/src/components/PostCard/PostHeader/PostHeader.connector.js
+++ b/src/components/PostCard/PostHeader/PostHeader.connector.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import { push } from 'connected-react-router'
-import { removePostFromUrl, editPostUrl, postUrl } from 'util/navigation'
+import { removePostFromUrl, editPostUrl, duplicatePostUrl, postUrl } from 'util/navigation'
 import getMe from 'store/selectors/getMe'
 import deletePost from 'store/actions/deletePost'
 import removePost from 'store/actions/removePost'
@@ -38,6 +38,9 @@ export function mapDispatchToProps (dispatch, props) {
     editPost: postId => props.editPost
       ? props.editPost(postId)
       : dispatch(push(editPostUrl(postId, props.routeParams))),
+    duplicatePost: postId => props.duplicatePost
+      ? props.duplicatePost(postId)
+      : dispatch(push(duplicatePostUrl(postId, props.routeParams))),
     deletePost: (postId, groupId, text) => props.deletePost
       ? props.deletePost(postId)
       : deletePostWithConfirm(postId, groupId, text),
@@ -59,7 +62,7 @@ export function mapDispatchToProps (dispatch, props) {
 export function mergeProps (stateProps, dispatchProps, ownProps) {
   const { currentUser, group } = stateProps
   const { id, creator } = ownProps
-  const { deletePost, editPost, fulfillPost, unfulfillPost, removePost, pinPost } = dispatchProps
+  const { deletePost, editPost, duplicatePost, fulfillPost, unfulfillPost, removePost, pinPost } = dispatchProps
   const isCreator = currentUser && creator && currentUser.id === creator.id
   const canEdit = isCreator
   const canModerate = currentUser && currentUser.canModerate(group)
@@ -70,6 +73,7 @@ export function mergeProps (stateProps, dispatchProps, ownProps) {
     ...ownProps,
     deletePost: isCreator ? (text) => deletePost(id, group ? group.id : null, text) : undefined,
     editPost: canEdit ? () => editPost(id) : undefined,
+    duplicatePost: () => duplicatePost(id),
     fulfillPost: isCreator ? () => fulfillPost(id) : undefined,
     unfulfillPost: isCreator ? () => unfulfillPost(id) : undefined,
     canFlag: !isCreator,

--- a/src/components/PostCard/PostHeader/PostHeader.connector.test.js
+++ b/src/components/PostCard/PostHeader/PostHeader.connector.test.js
@@ -37,10 +37,12 @@ describe('mapDispatchToProps', () => {
     expect(dispatchProps).toMatchSnapshot()
     dispatchProps.removePost(10)
     dispatchProps.editPost(10)
-    expect(dispatch).toHaveBeenCalledTimes(2)
+    dispatchProps.duplicatePost(10)
+    expect(dispatch).toHaveBeenCalledTimes(3)
 
     dispatchProps.deletePost(1)
     dispatchProps.pinPost(2, 3)
+    dispatchProps.duplicatePost(10)
     expect(dispatch.mock.calls).toMatchSnapshot()
   })
 
@@ -79,6 +81,7 @@ describe('mergeProps', () => {
   const dispatchProps = {
     removePost: jest.fn(),
     deletePost: jest.fn(),
+    duplicatePost: jest.fn(),
     editPost: jest.fn(),
     pinPost: jest.fn()
   }
@@ -86,6 +89,7 @@ describe('mergeProps', () => {
   beforeEach(() => {
     dispatchProps.removePost.mockReset()
     dispatchProps.editPost.mockReset()
+    dispatchProps.duplicatePost.mockReset()
     dispatchProps.deletePost.mockReset()
     dispatchProps.pinPost.mockReset()
   })
@@ -151,7 +155,7 @@ describe('mergeProps', () => {
   })
 
   describe('as non-moderator', () => {
-    it("can delete own posts, can't pin posts", () => {
+    it("can delete and edit own posts, can duplicate any posts, can't pin posts", () => {
       const session = orm.session(orm.getEmptyState())
       const group = session.Group.create({ id: 33, slug: 'mygroup' })
       session.Me.create({ id: 20,
@@ -168,19 +172,26 @@ describe('mergeProps', () => {
       const ownProps = { id: 20, routeParams: { groupSlug: 'mygroup' }, creator: { id: 20 } }
       const stateProps = mapStateToProps(state, ownProps)
 
-      const { deletePost, removePost, editPost, pinPost } = mergeProps(stateProps, dispatchProps, ownProps)
+      const { deletePost, removePost, editPost, duplicatePost, pinPost } = mergeProps(stateProps, dispatchProps, ownProps)
 
       expect(editPost).toBeTruthy()
       expect(deletePost).toBeTruthy()
       expect(removePost).toBeFalsy()
       expect(pinPost).toBeFalsy()
+      expect(duplicatePost).toBeTruthy()
 
       deletePost('lettuce')
       expect(dispatchProps.deletePost).toHaveBeenCalledWith(20, 33, 'lettuce')
+
+      editPost('lettuce')
+      expect(dispatchProps.editPost).toHaveBeenCalledWith(20)
+
+      duplicatePost('lettuce')
+      expect(dispatchProps.duplicatePost).toHaveBeenCalledWith(20)
     })
   })
 
-  it('cannot delete or remove posts if not creator or moderator', () => {
+  it('cannot delete, edit, or remove posts if not creator or moderator but can duplicate posts', () => {
     const session = orm.session(orm.getEmptyState())
     const group = session.Group.create({ id: 33, slug: 'mygroup' })
     session.Me.create({ id: 20,
@@ -197,10 +208,11 @@ describe('mergeProps', () => {
     const ownProps = { id: 20, routeParams: { groupSlug: 'mygroup' }, creator: { id: 33 } }
     const stateProps = mapStateToProps(state, ownProps)
 
-    const { deletePost, removePost, editPost } = mergeProps(stateProps, dispatchProps, ownProps)
+    const { deletePost, removePost, editPost, duplicatePost } = mergeProps(stateProps, dispatchProps, ownProps)
 
     expect(deletePost).toBeFalsy()
     expect(removePost).toBeFalsy()
     expect(editPost).toBeFalsy()
+    expect(duplicatePost).toBeTruthy()
   })
 })

--- a/src/components/PostCard/PostHeader/PostHeader.js
+++ b/src/components/PostCard/PostHeader/PostHeader.js
@@ -51,6 +51,7 @@ class PostHeader extends PureComponent {
       constrained,
       editPost,
       deletePost,
+      duplicatePost,
       removePost,
       pinPost,
       highlightProps,
@@ -81,6 +82,7 @@ class PostHeader extends PureComponent {
       { icon: 'Edit', label: t('Edit'), onClick: editPost },
       { icon: 'Copy', label: t('Copy Link'), onClick: copyLink },
       { icon: 'Flag', label: t('Flag'), onClick: this.flagPostFunc() },
+      { icon: 'Duplicate', label: t('Duplicate'), onClick: duplicatePost },
       { icon: 'Trash', label: t('Delete'), onClick: deletePost ? () => deletePost(t('Are you sure you want to delete this post?')) : undefined, red: true },
       { icon: 'Trash', label: t('Remove From Group'), onClick: removePost, red: true }
     ], item => isFunction(item.onClick))

--- a/src/components/PostCard/PostHeader/PostHeader.test.js
+++ b/src/components/PostCard/PostHeader/PostHeader.test.js
@@ -35,7 +35,7 @@ it('matches snapshot', () => {
   expect(wrapper).toMatchSnapshot()
   wrapper.setProps({ context, type: 'request', groups })
   expect(wrapper).toMatchSnapshot()
-  wrapper.setProps({ deletePost: () => {}, editPost: () => {} })
+  wrapper.setProps({ deletePost: () => {}, editPost: () => {}, duplicatePost: () => {} })
   expect(wrapper).toMatchSnapshot()
 })
 
@@ -64,7 +64,7 @@ it('matches announcement snapshot', () => {
   expect(wrapper).toMatchSnapshot()
   wrapper.setProps({ context, type: 'request', groups })
   expect(wrapper).toMatchSnapshot()
-  wrapper.setProps({ deletePost: () => {}, editPost: () => {} })
+  wrapper.setProps({ deletePost: () => {}, editPost: () => {}, duplicatePost: () => {} })
   expect(wrapper).toMatchSnapshot()
 })
 

--- a/src/components/PostCard/PostHeader/__snapshots__/PostHeader.connector.test.js.snap
+++ b/src/components/PostCard/PostHeader/__snapshots__/PostHeader.connector.test.js.snap
@@ -50,6 +50,7 @@ Array [
 exports[`mapDispatchToProps maps the action generators 1`] = `
 Object {
   "deletePost": [Function],
+  "duplicatePost": [Function],
   "editPost": [Function],
   "fulfillPost": [Function],
   "pinPost": [Function],
@@ -94,6 +95,17 @@ Array [
   ],
   Array [
     Object {
+      "payload": Object {
+        "args": Array [
+          "/groups/mygroup/create/post?fromPostId=10",
+        ],
+        "method": "push",
+      },
+      "type": "@@router/CALL_HISTORY_METHOD",
+    },
+  ],
+  Array [
+    Object {
       "graphql": Object {
         "query": "mutation ($postId: ID, $groupId: ID) {
         pinPost(postId: $postId, groupId: $groupId) {
@@ -111,6 +123,17 @@ Array [
         "postId": 2,
       },
       "type": "PostHeader/PIN_POST",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "args": Array [
+          "/groups/mygroup/create/post?fromPostId=10",
+        ],
+        "method": "push",
+      },
+      "type": "@@router/CALL_HISTORY_METHOD",
     },
   ],
 ]

--- a/src/components/PostCard/PostHeader/__snapshots__/PostHeader.test.js.snap
+++ b/src/components/PostCard/PostHeader/__snapshots__/PostHeader.test.js.snap
@@ -304,6 +304,11 @@ exports[`matches announcement snapshot 3`] = `
                 "onClick": [Function],
               },
               Object {
+                "icon": "Duplicate",
+                "label": "Duplicate",
+                "onClick": [Function],
+              },
+              Object {
                 "icon": "Trash",
                 "label": "Delete",
                 "onClick": [Function],
@@ -560,6 +565,11 @@ exports[`matches snapshot 3`] = `
               Object {
                 "icon": "Copy",
                 "label": "Copy Link",
+                "onClick": [Function],
+              },
+              Object {
+                "icon": "Duplicate",
+                "label": "Duplicate",
                 "onClick": [Function],
               },
               Object {

--- a/src/components/PostEditor/PostEditor.connector.js
+++ b/src/components/PostEditor/PostEditor.connector.js
@@ -46,7 +46,7 @@ export function mapStateToProps (state, props) {
   const fetchLinkPreviewPending = isPendingFor(FETCH_LINK_PREVIEW, state)
   const uploadAttachmentPending = getUploadAttachmentPending(state)
   const fromPostId = getQuerystringParam('fromPostId', null, props)
-  const editingPostId = getRouteParam('postId', state, props) || fromPostId
+  const editingPostId = getRouteParam('postId', state, props)
   const uploadFileAttachmentPending = getUploadAttachmentPending(state, { type: 'post', id: editingPostId, attachmentType: 'file' })
   const uploadImageAttachmentPending = getUploadAttachmentPending(state, { type: 'post', id: editingPostId, attachmentType: 'image' })
   const postPending = isPendingFor([CREATE_POST, CREATE_PROJECT], state)
@@ -57,7 +57,7 @@ export function mapStateToProps (state, props) {
     post = props.post || presentPost(getPost(state, props))
     editing = !!post || loading
   } else if (fromPostId) {
-    post = props.post || presentPost(getPost(state, props))
+    post = presentPost(getPost(state, props))
     post.title = `Copy of ${post.title.slice(0, MAX_TITLE_LENGTH - 8)}`
   }
   const imageAttachments = getAttachments(state, { type: 'post', id: editingPostId, attachmentType: 'image' })

--- a/src/components/PostEditor/PostEditor.connector.js
+++ b/src/components/PostEditor/PostEditor.connector.js
@@ -57,7 +57,7 @@ export function mapStateToProps (state, props) {
     post = props.post || presentPost(getPost(state, props))
     editing = !!post || loading
   } else if (fromPostId) {
-    post = presentPost(getPost(state, props))
+    post = props.post || presentPost(getPost(state, props))
     post.title = `Copy of ${post.title.slice(0, MAX_TITLE_LENGTH - 8)}`
   }
   const imageAttachments = getAttachments(state, { type: 'post', id: editingPostId, attachmentType: 'image' })

--- a/src/components/PostEditor/PostEditor.connector.js
+++ b/src/components/PostEditor/PostEditor.connector.js
@@ -33,6 +33,7 @@ import {
   getLinkPreview,
   setAnnouncement
 } from './PostEditor.store'
+import { MAX_TITLE_LENGTH } from './PostEditor'
 
 export function mapStateToProps (state, props) {
   const currentUser = getMe(state)
@@ -44,7 +45,8 @@ export function mapStateToProps (state, props) {
   const linkPreviewStatus = get('linkPreviewStatus', state[MODULE_NAME])
   const fetchLinkPreviewPending = isPendingFor(FETCH_LINK_PREVIEW, state)
   const uploadAttachmentPending = getUploadAttachmentPending(state)
-  const editingPostId = getRouteParam('postId', state, props)
+  const fromPostId = getQuerystringParam('fromPostId', null, props)
+  const editingPostId = getRouteParam('postId', state, props) || fromPostId
   const uploadFileAttachmentPending = getUploadAttachmentPending(state, { type: 'post', id: editingPostId, attachmentType: 'file' })
   const uploadImageAttachmentPending = getUploadAttachmentPending(state, { type: 'post', id: editingPostId, attachmentType: 'image' })
   const postPending = isPendingFor([CREATE_POST, CREATE_PROJECT], state)
@@ -54,6 +56,9 @@ export function mapStateToProps (state, props) {
   if (getRouteParam('action', null, props) === 'edit') {
     post = props.post || presentPost(getPost(state, props))
     editing = !!post || loading
+  } else if (fromPostId) {
+    post = props.post || presentPost(getPost(state, props))
+    post.title = `Copy of ${post.title.slice(0, MAX_TITLE_LENGTH - 8)}`
   }
   const imageAttachments = getAttachments(state, { type: 'post', id: editingPostId, attachmentType: 'image' })
   const fileAttachments = getAttachments(state, { type: 'post', id: editingPostId, attachmentType: 'file' })
@@ -125,9 +130,9 @@ export const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const goToPost = createPostAction => {
     const id = get('payload.data.createPost.id', createPostAction)
     // * The single letter params are used in the Stream and elsewhere
-    // and translate as follow: `s`(ort), `t`(ab), `q`(uery/search)
+    // and translate as follow: `s`(ort), `t`(ab), `q`(uery/'search')
     // The remaining whitelisted params are for the map view.
-    const querystringWhitelist = ['s', 't', 'q', 'zoom', 'center', 'lat', 'lng']
+    const querystringWhitelist = ['s', 't', 'q', 'search', 'zoom', 'center', 'lat', 'lng']
     const querystringParams = ownProps?.location && getQuerystringParam(querystringWhitelist, null, ownProps)
     const postPath = postUrl(id, ownProps?.match?.params, querystringParams)
 

--- a/src/components/PostEditor/PostEditor.connector.test.js
+++ b/src/components/PostEditor/PostEditor.connector.test.js
@@ -1,5 +1,6 @@
 import { mapStateToProps, mapDispatchToProps, mergeProps } from './PostEditor.connector'
 import orm from 'store/models'
+import { Model } from 'redux-orm'
 import { CREATE_POST } from 'store/constants'
 import { MAX_TITLE_LENGTH } from './PostEditor'
 
@@ -119,22 +120,39 @@ describe('mapStateToProps', () => {
   it('returns the right keys for duplicating a post', () => {
     const props = {
       ...requiredProps,
-      match: {
-        params: {
-          action: 'create'
-        }
-      },
-      location: {
-        search: '?fromPostId=2'
-      },
-      post: {
-        title: 'x'.repeat(MAX_TITLE_LENGTH - 1)
-      }
+      match: { params: {} },
+      location: { search: '?fromPostId=3' },
+      groupOptions: []
     }
-    const expectedTitle = `Copy of ${props.post.title.slice(0, MAX_TITLE_LENGTH - 8)}`
+    const title = 'x'.repeat(MAX_TITLE_LENGTH - 1)
+    const expectedTitle = `Copy of ${title.slice(0, MAX_TITLE_LENGTH - 8)}`
+    Model.withId = jest.fn(() => {
+      return {
+        ref: { title },
+        postMemberships: { toRefArray: () => [] },
+        commenters: { toModelArray: () => [] },
+        groups: { toModelArray: () => [] },
+        attachments: {
+          orderBy: () => {
+            return {
+              toModelArray: () => [],
+              filter: () => {
+                return {
+                  toRefArray: () => [],
+                  toModelArray: () => []
+                }
+              }
+            }
+          }
+        },
+        topics: { toModelArray: () => { return { map: () => [] } } },
+        members: { toModelArray: () => { return { map: () => [] } } },
+        eventInvitations: { toModelArray: () => { return { map: () => [] } } }
+      }
+    })
 
     const { post } = mapStateToProps(state, props)
-    expect(post.title).toEqual(expectedTitle)
+    expect(post.title).toBe(expectedTitle)
   })
 })
 

--- a/src/components/PostEditor/PostEditor.connector.test.js
+++ b/src/components/PostEditor/PostEditor.connector.test.js
@@ -1,6 +1,5 @@
 import { mapStateToProps, mapDispatchToProps, mergeProps } from './PostEditor.connector'
 import orm from 'store/models'
-import { Model } from 'redux-orm'
 import { CREATE_POST } from 'store/constants'
 import { MAX_TITLE_LENGTH } from './PostEditor'
 
@@ -122,34 +121,10 @@ describe('mapStateToProps', () => {
       ...requiredProps,
       match: { params: {} },
       location: { search: '?fromPostId=3' },
-      groupOptions: []
+      groupOptions: [],
+      post: { title: 'x'.repeat(MAX_TITLE_LENGTH - 1) }
     }
-    const title = 'x'.repeat(MAX_TITLE_LENGTH - 1)
-    const expectedTitle = `Copy of ${title.slice(0, MAX_TITLE_LENGTH - 8)}`
-    Model.withId = jest.fn(() => {
-      return {
-        ref: { title },
-        postMemberships: { toRefArray: () => [] },
-        commenters: { toModelArray: () => [] },
-        groups: { toModelArray: () => [] },
-        attachments: {
-          orderBy: () => {
-            return {
-              toModelArray: () => [],
-              filter: () => {
-                return {
-                  toRefArray: () => [],
-                  toModelArray: () => []
-                }
-              }
-            }
-          }
-        },
-        topics: { toModelArray: () => { return { map: () => [] } } },
-        members: { toModelArray: () => { return { map: () => [] } } },
-        eventInvitations: { toModelArray: () => { return { map: () => [] } } }
-      }
-    })
+    const expectedTitle = `Copy of ${props.post.title.slice(0, MAX_TITLE_LENGTH - 8)}`
 
     const { post } = mapStateToProps(state, props)
     expect(post.title).toBe(expectedTitle)

--- a/src/components/PostEditor/PostEditor.connector.test.js
+++ b/src/components/PostEditor/PostEditor.connector.test.js
@@ -1,6 +1,7 @@
 import { mapStateToProps, mapDispatchToProps, mergeProps } from './PostEditor.connector'
 import orm from 'store/models'
 import { CREATE_POST } from 'store/constants'
+import { MAX_TITLE_LENGTH } from './PostEditor'
 
 let state, requiredProps
 beforeAll(() => {
@@ -81,6 +82,60 @@ describe('mapStateToProps', () => {
     }
     expect(mapStateToProps(newState, props)).toMatchSnapshot()
   })
+  it('returns the right keys for a new post', () => {
+    const props = {
+      ...requiredProps,
+      match: {
+        params: {
+          slug: 'foo'
+        }
+      }
+    }
+    expect(mapStateToProps(state, props)).toMatchSnapshot()
+  })
+
+  it('sets myModeratedGroups appropriately', () => {
+    expect(mapStateToProps(state, requiredProps).myModeratedGroups.length).toEqual(1)
+  })
+
+  it('returns the right keys for edit post', () => {
+    const props = {
+      ...requiredProps,
+      match: {
+        params: {
+          postId: '2',
+          action: 'edit'
+        }
+      },
+      post: 'lettuce'
+    }
+
+    const { editingPostId, post, editing } = mapStateToProps(state, props)
+    expect(editingPostId).toEqual('2')
+    expect(editing).toBe(true)
+    expect(post).toEqual('lettuce')
+  })
+
+  it('returns the right keys for duplicating a post', () => {
+    const props = {
+      ...requiredProps,
+      match: {
+        params: {
+          action: 'create'
+        }
+      },
+      location: {
+        search: '?fromPostId=2'
+      },
+      post: {
+        title: 'x'.repeat(MAX_TITLE_LENGTH - 1)
+      }
+    }
+    const expectedTitle = `Copy of ${props.post.title.slice(0, MAX_TITLE_LENGTH - 8)}`
+
+    const { post } = mapStateToProps(state, props)
+    expect(post.title).toEqual(expectedTitle)
+  })
 })
 
 describe('mapDispatchToProps', () => {
@@ -133,5 +188,30 @@ describe('mergeProps', () => {
     mergedProps.goToPost(action)
     expect(dispatchProps.goToUrl).toHaveBeenCalled()
     expect(dispatchProps.goToUrl.mock.calls).toMatchSnapshot()
+  })
+
+  it('goToPost redirects with the same stream params', () => {
+    const stateProps = {
+      groupSlug: 'theslug'
+    }
+    const dispatchProps = {
+      goToUrl: postPath => { return postPath }
+    }
+    const ownProps = {
+      location: {
+        search: '?s=created&t=discussion&search=hylo'
+      }
+    }
+    const action = {
+      payload: {
+        data: {
+          createPost: {
+            id: 123
+          }
+        }
+      }
+    }
+    const mergedProps = mergeProps(stateProps, dispatchProps, ownProps)
+    expect(mergedProps.goToPost(action)).toEqual('/all/post/123?s=created&t=discussion&search=hylo')
   })
 })

--- a/src/components/PostEditor/PostEditor.js
+++ b/src/components/PostEditor/PostEditor.js
@@ -102,7 +102,7 @@ class PostEditor extends React.Component {
       post: currentPost,
       titlePlaceholder: this.titlePlaceholderForPostType(currentPost.type),
       detailPlaceholder: this.detailPlaceholderForPostType(currentPost.type),
-      valid: editing === true, // if we're editing, than it's already valid upon entry.
+      valid: editing === true || !!currentPost.title, // valid upon entry if editing or duplicating
       announcementSelected: announcementSelected,
       toggleAnnouncementModal: false,
       showPostTypeMenu: false,

--- a/src/components/PostEditor/__snapshots__/PostEditor.connector.test.js.snap
+++ b/src/components/PostEditor/__snapshots__/PostEditor.connector.test.js.snap
@@ -78,6 +78,69 @@ Object {
 }
 `;
 
+exports[`mapStateToProps returns the right keys for a new post 2`] = `
+Object {
+  "announcementSelected": undefined,
+  "context": undefined,
+  "currentGroup": null,
+  "currentUser": SessionBoundModel {
+    "_fields": Object {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  "editing": false,
+  "editingPostId": undefined,
+  "ensureLocationIdIfCoordinate": [Function],
+  "fetchLinkPreviewPending": false,
+  "fileAttachments": Array [],
+  "groupOptions": Array [
+    SessionBoundModel {
+      "_fields": Object {
+        "id": "100",
+        "name": "bar",
+        "slug": "bar",
+      },
+    },
+    SessionBoundModel {
+      "_fields": Object {
+        "id": "99",
+        "name": "foo",
+        "slug": "foo",
+      },
+    },
+  ],
+  "groupSlug": undefined,
+  "imageAttachments": Array [],
+  "isEvent": false,
+  "isProject": false,
+  "linkPreview": null,
+  "linkPreviewStatus": false,
+  "loading": false,
+  "location": Object {
+    "search": "",
+  },
+  "myModeratedGroups": Array [
+    SessionBoundModel {
+      "_fields": Object {
+        "id": "99",
+        "name": "foo",
+        "slug": "foo",
+      },
+    },
+  ],
+  "post": null,
+  "postPending": false,
+  "postType": undefined,
+  "showFiles": false,
+  "showImages": false,
+  "topic": null,
+  "topicName": undefined,
+  "uploadFileAttachmentPending": false,
+  "uploadImageAttachmentPending": false,
+}
+`;
+
 exports[`mapStateToProps returns the right keys for a new post while pending 1`] = `
 Object {
   "announcementSelected": undefined,

--- a/src/routes/AuthLayoutRouter/components/TopNav/NotificationsDropdown/NotificationsDropdown.test.js
+++ b/src/routes/AuthLayoutRouter/components/TopNav/NotificationsDropdown/NotificationsDropdown.test.js
@@ -1,4 +1,4 @@
-import NotificationsDropdown, { Notification, NotificationHeader, NotificationBody } from './NotificationsDropdown'
+import NotificationsDropdown, { Notification } from './NotificationsDropdown'
 import { shallow } from 'enzyme'
 import React from 'react'
 import {
@@ -8,7 +8,6 @@ import {
   ACTION_APPROVED_JOIN_REQUEST,
   ACTION_MENTION,
   ACTION_COMMENT_MENTION,
-  ACTION_ANNOUNCEMENT,
   ACTION_DONATION_TO,
   ACTION_DONATION_FROM
   // ACTION_EVENT_INVITATION
@@ -149,18 +148,6 @@ const notifications = [
   mentionNotification,
   commentMentionNotification
 ]
-
-const announcementNotification = {
-  id: 10,
-  activity: {
-    actor: u2,
-    action: ACTION_ANNOUNCEMENT,
-    meta: {},
-    post: { title: 'Announcement' },
-    unread: true
-  },
-  createdAt: new Date(Date.UTC(1995, 11, 17, 3, 23, 0))
-}
 
 // const eventInvitationNotification = {
 //   id: 10,

--- a/src/routes/PostDetail/PostDetail.connector.test.js
+++ b/src/routes/PostDetail/PostDetail.connector.test.js
@@ -10,7 +10,10 @@ describe('mapStateToProps', () => {
       pending: {}
     }
     const props = {
-      match: {}
+      match: {},
+      location: {
+        search: ''
+      }
     }
     expect(mapStateToProps(state, props)).toMatchSnapshot()
   })

--- a/src/store/selectors/getPost.js
+++ b/src/store/selectors/getPost.js
@@ -1,10 +1,11 @@
 import { createSelector as ormCreateSelector } from 'redux-orm'
 import orm from 'store/models'
 import getRouteParam from 'store/selectors/getRouteParam'
+import getQuerystringParam from 'store/selectors/getQuerystringParam'
 
 const getPost = ormCreateSelector(
   orm,
-  (state, props) => getRouteParam('postId', state, props),
+  (state, props) => getRouteParam('postId', state, props) || getQuerystringParam('fromPostId', state, props),
   ({ Post }, id) => {
     return Post.withId(id)
   }

--- a/src/store/selectors/getPost.test.js
+++ b/src/store/selectors/getPost.test.js
@@ -1,9 +1,36 @@
+import { Model } from 'redux-orm'
 import orm from 'store/models'
 import getPost from 'store/selectors/getPost'
 
-describe('getPost', () => {
-  it("returns null if post doesn't exist", () => {
-    const session = orm.session(orm.getEmptyState())
+let session = null
+
+beforeAll(() => {
+  session = orm.session(orm.getEmptyState())
+})
+
+describe('getPost for non-existant post', () => {
+  it('returns null', () => {
     expect(getPost({ orm: session.state }, { match: { params: { postId: '1' } } })).toEqual(null)
+  })
+})
+
+describe('getPost for existing post', () => {
+  it('returns post for editing (and ignores duplication param)', () => {
+    const props = {
+      match: { params: { postId: '2' } }
+    }
+    Model.withId = jest.fn(id => id)
+    expect(getPost({ orm: session.state }, props)).toBe('2')
+    expect(Model.withId.mock.results[0].value).toBe('2')
+  })
+
+  it('returns post for duplicating', () => {
+    const props = {
+      match: { params: {} },
+      location: { search: '?fromPostId=3' }
+    }
+    Model.withId = jest.fn(id => id)
+    expect(getPost({ orm: session.state }, props)).toBe('3')
+    expect(Model.withId.mock.results[0].value).toBe('3')
   })
 })

--- a/src/util/navigation.js
+++ b/src/util/navigation.js
@@ -114,6 +114,10 @@ export function editPostUrl (id, opts = {}, querystringParams = {}) {
   return postUrl(id, { ...opts, action: 'edit' }, querystringParams)
 }
 
+export function duplicatePostUrl (id, opts = {}) {
+  return createPostUrl(opts, { fromPostId: id })
+}
+
 export function postCommentUrl ({ postId, commentId, ...opts }, querystringParams = {}) {
   return `${postUrl(postId, opts, querystringParams)}/comments/${commentId}`
 }

--- a/src/util/navigation.test.js
+++ b/src/util/navigation.test.js
@@ -1,7 +1,9 @@
 import {
   removePostFromUrl,
   postUrl,
-  gotoExternalUrl
+  gotoExternalUrl,
+  editPostUrl,
+  duplicatePostUrl
 } from './navigation'
 
 describe('postUrl', () => {
@@ -57,6 +59,20 @@ describe('removePostFromUrl', () => {
   it('should remove default Post route', () => {
     const result = removePostFromUrl('/groups/somegroup/post/1234')
     expect(result).toEqual('/groups/somegroup')
+  })
+})
+
+describe('editPostUrl', () => {
+  it('should return edit action URL with postId', () => {
+    const result = editPostUrl('1234', { context: 'groups', groupSlug: 'test' })
+    expect(result).toEqual('/groups/test/post/1234/edit')
+  })
+})
+
+describe('duplicatePostUrl', () => {
+  it('should return create action URL with postId query param fromPostId', () => {
+    const result = duplicatePostUrl('1234', { context: 'groups', groupSlug: 'test' })
+    expect(result).toEqual('/groups/test/create/post?fromPostId=1234')
   })
 })
 


### PR DESCRIPTION
Added "Duplicate" option to three-dot menu in PostDetails with es translation and tests (1st commit).
Enables the Post button on entry into CreateModal (2nd commit).