### PR TITLE
Evo 1327 title length error popup awkwardness

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -705,7 +705,7 @@
   "This will only be sent as an Announcement to the groups where you are a Moderator. For other groups it will be shared as a regular Post.": "This will only be sent as an Announcement to the groups where you are a Moderator. For other groups it will be shared as a regular Post.",
   "Timeframe": "Timeframe",
   "Title": "Title",
-  "Title can't have more than {{maxTitleLength}} characters": "Title can't have more than {{maxTitleLength}} characters",
+  "Title limited to {{maxTitleLength}} characters": "Title limited to {{maxTitleLength}} characters",
   "To": "To",
   "To accept financial contributions for this project, you have\n                  to connect a Stripe account. Go to": "To accept financial contributions for this project, you have\n                  to connect a Stripe account. Go to",
   "To follow the tour look for the pulsing beacons!": "To follow the tour look for the pulsing beacons!",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -711,7 +711,7 @@
   "This will allow {{appName}} to:": "Esto permitirá que {{appName}}:",
   "This will only be sent as an Announcement to the groups where you are a Moderator. For other groups it will be shared as a regular Post.": "Esto solo se enviará como un Anuncio a los grupos en los que sea Moderador. Para otros grupos, se compartirá como una publicación normal.",
   "Timeframe": "Periodo de tiempo",
-  "Title can't have more than {{maxTitleLength}} characters": "El título no puede tener más de {{maxTitleLength}} caracteres",
+  "Title limited to {{maxTitleLength}} characters": "Título limitado a {{maxTitleLength}} caracteres",
   "To": "A",
   "To accept financial contributions for this project, you have\n                  to connect a Stripe account. Go to": "Para aceptar contribuciones financieras para este proyecto, debes\n  conectar una cuenta de Stripe. Ve a                  \npara conectar una cuenta de Stripe. \nIr a",
   "To follow the tour look for the pulsing beacons!": "¡Para seguir el recorrido busca las balizas pulsantes!",

--- a/src/components/PostEditor/PostEditor.js
+++ b/src/components/PostEditor/PostEditor.js
@@ -728,11 +728,6 @@ class PostEditor extends React.Component {
             togglePublic={this.togglePublic}
             isPublic={!!post.isPublic}
           />
-          {canHaveTimes && dateError && (
-            <span styleName='title-error'>
-              {t('End Time must be after Start Time')}
-            </span>
-          )}
           {canHaveTimes && (
             <div styleName='footerSection'>
               <div styleName='footerSection-label'>{t('Timeframe')}</div>
@@ -750,6 +745,11 @@ class PostEditor extends React.Component {
                 />
               </div>
             </div>
+          )}
+          {canHaveTimes && dateError && (
+            <span styleName='datepicker-error'>
+              {t('End Time must be after Start Time')}
+            </span>
           )}
           {hasLocation && (
             <div styleName='footerSection'>

--- a/src/components/PostEditor/PostEditor.js
+++ b/src/components/PostEditor/PostEditor.js
@@ -106,7 +106,7 @@ class PostEditor extends React.Component {
       announcementSelected: announcementSelected,
       toggleAnnouncementModal: false,
       showPostTypeMenu: false,
-      titleLengthError: false,
+      titleLengthError: currentPost.title?.length >= MAX_TITLE_LENGTH,
       dateError: false,
       allowAddTopic: true
     }

--- a/src/components/PostEditor/PostEditor.js
+++ b/src/components/PostEditor/PostEditor.js
@@ -646,7 +646,7 @@ class PostEditor extends React.Component {
               maxLength={MAX_TITLE_LENGTH}
             />
             {titleLengthError && (
-              <span styleName='title-error'>{t('Title can\'t have more than {{maxTitleLength}} characters', { maxTitleLength: MAX_TITLE_LENGTH })}</span>
+              <span styleName='title-error'>{t('Title limited to {{maxTitleLength}} characters', { maxTitleLength: MAX_TITLE_LENGTH })}</span>
             )}
             <HyloEditor
               styleName='editor'

--- a/src/components/PostEditor/PostEditor.scss
+++ b/src/components/PostEditor/PostEditor.scss
@@ -291,6 +291,18 @@ $wrapperBorderRadius: 8px;
   display: none;
 }
 
+.datepicker-error {
+  color: white;
+  background-color: $color-amaranth;
+  width: 100%;
+  margin-left: 10px;
+  padding-top: 0px;
+  padding-bottom: 2px;
+  padding-right: 10px;
+  padding-left: 10px;
+  border-radius: 7px;
+}
+
 .title-error {
   color: black;
   background-color: $color-yellow-orange;

--- a/src/components/PostEditor/PostEditor.scss
+++ b/src/components/PostEditor/PostEditor.scss
@@ -292,14 +292,16 @@ $wrapperBorderRadius: 8px;
 }
 
 .title-error {
-  color: white;
-  background-color: $color-amaranth;
-  float: right;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  color: black;
+  background-color: $color-yellow-orange;
+  width: 100%;
+  position: relative;
+  top: -15px;
+  padding-top: 0px;
+  padding-bottom: 2px;
   padding-right: 10px;
   padding-left: 10px;
-  border-radius: 10px;
+  border-radius: 7px;
 }
 
 .accept-contributions-help {

--- a/src/components/PostEditor/PostEditor.test.js
+++ b/src/components/PostEditor/PostEditor.test.js
@@ -179,7 +179,6 @@ describe('PostEditor', () => {
       expect(setIsDirty).toHaveBeenCalled()
     })
 
-    // NB: MAX_TITLE_LENGTH triggers the error (warning) to the user that they hit the max
     test('tests for valid title length', () => {
       const wrapper = shallow(<PostEditor {...props} />)
       const titleElement = wrapper.find('input').first()
@@ -187,7 +186,6 @@ describe('PostEditor', () => {
       expect(wrapper.state().titleLengthError).toBeFalsy()
     })
 
-    // NB: MAX_TITLE_LENGTH triggers the error (warning) to the user that they hit the max
     test('tests for invalid title length', () => {
       const wrapper = shallow(<PostEditor {...props} />)
       const titleElement = wrapper.find('input').first()

--- a/src/components/PostEditor/PostEditor.test.js
+++ b/src/components/PostEditor/PostEditor.test.js
@@ -48,6 +48,7 @@ describe('PostEditor', () => {
       }
       const wrapper = shallow(<PostEditor {...props} />)
       expect(wrapper).toMatchSnapshot()
+      expect(wrapper.state().titleLengthError).toBe(false)
     })
 
     const renderForType = (type) => {
@@ -191,6 +192,18 @@ describe('PostEditor', () => {
       const titleElement = wrapper.find('input').first()
       titleElement.simulate('change', { target: { value: 'x'.repeat(MAX_TITLE_LENGTH) } })
       expect(wrapper.state().titleLengthError).toBeTruthy()
+    })
+
+    test('tests titleLengthError initialized to true for title at max', () => {
+      props.post.title = 'x'.repeat(MAX_TITLE_LENGTH)
+      const wrapper = shallow(<PostEditor {...props} />)
+      expect(wrapper.state().titleLengthError).toBe(true)
+    })
+
+    test('tests titleLengthError initialized to false for title not at max', () => {
+      props.post.title = 'x'.repeat(MAX_TITLE_LENGTH - 1)
+      const wrapper = shallow(<PostEditor {...props} />)
+      expect(wrapper.state().titleLengthError).toBe(false)
     })
   })
 


### PR DESCRIPTION
Fixes #1327:

- Fix post title max error message position
- Change wording of post title max message from error to warning
- Initialize titleMaxError on post editor entry to fix UX issue
- Fix post editor date error message position

### Post editor, no error message
<img width="586" alt="Screenshot 2024-04-09 at 12 55 20 PM" src="https://github.com/Hylozoic/hylo-evo/assets/5772/d2e7617c-286f-4d35-b067-2e1ed931f545">

### Post editor, title max warning
<img width="564" alt="Screenshot 2024-04-09 at 10 22 31 AM" src="https://github.com/Hylozoic/hylo-evo/assets/5772/3a0673dc-2761-4eca-bea3-5fb0e26f1221">

### Post editor, title max warning, constrained width
<img width="408" alt="Screenshot 2024-04-09 at 10 22 44 AM" src="https://github.com/Hylozoic/hylo-evo/assets/5772/7382d013-3332-4124-a364-5c566f4917d2">

### Post editor, date error message before PR
<img width="552" alt="Screenshot 2024-04-09 at 10 24 15 AM" src="https://github.com/Hylozoic/hylo-evo/assets/5772/9fcf5fc1-5e38-4eab-8ef2-016d41a000e1">

### Post editor, date error message with PR
<img width="509" alt="Screenshot 2024-04-09 at 10 37 38 AM" src="https://github.com/Hylozoic/hylo-evo/assets/5772/0170b436-e532-48d2-ad3d-72e37ab08644">