### PR TITLE
Fix for dup post change of type losing content

### DIFF
--- a/src/components/PostEditor/PostEditor.js
+++ b/src/components/PostEditor/PostEditor.js
@@ -27,6 +27,7 @@ import { PROJECT_CONTRIBUTIONS } from 'config/featureFlags'
 import { MAX_POST_TOPICS } from 'util/constants'
 import { sanitizeURL } from 'util/url'
 import Tooltip from 'components/Tooltip'
+import setQuerystringParam from 'store/selectors/setQuerystringParam'
 
 export const MAX_TITLE_LENGTH = 80
 
@@ -169,7 +170,7 @@ class PostEditor extends React.Component {
     this.setIsDirty(true)
     changeQueryString({
       pathname: location.pathname,
-      search: `?newPostType=${type}`
+      search: setQuerystringParam('newPostType', type, location)
     })
 
     const showPostTypeMenu = this.state.showPostTypeMenu

--- a/src/components/PostEditor/PostEditor.js
+++ b/src/components/PostEditor/PostEditor.js
@@ -27,7 +27,7 @@ import { PROJECT_CONTRIBUTIONS } from 'config/featureFlags'
 import { MAX_POST_TOPICS } from 'util/constants'
 import { sanitizeURL } from 'util/url'
 import Tooltip from 'components/Tooltip'
-import setQuerystringParam from 'store/selectors/setQuerystringParam'
+import { setQuerystringParam } from 'util/navigation'
 
 export const MAX_TITLE_LENGTH = 80
 

--- a/src/store/selectors/setQuerystringParam.js
+++ b/src/store/selectors/setQuerystringParam.js
@@ -1,7 +1,0 @@
-export const setQuerystringParam = (key, value, location) => {
-  const querystringParams = new URLSearchParams(location.search)
-  querystringParams.set(key, value)
-  return querystringParams.toString()
-}
-
-export default setQuerystringParam

--- a/src/store/selectors/setQuerystringParam.js
+++ b/src/store/selectors/setQuerystringParam.js
@@ -1,0 +1,7 @@
+export const setQuerystringParam = (key, value, location) => {
+  const querystringParams = new URLSearchParams(location.search)
+  querystringParams.set(key, value)
+  return querystringParams.toString()
+}
+
+export default setQuerystringParam

--- a/src/util/navigation.js
+++ b/src/util/navigation.js
@@ -167,6 +167,12 @@ export function topicUrl (topicName, opts) {
 
 // URL utility functions
 
+export function setQuerystringParam (key, value, location) {
+  const querystringParams = new URLSearchParams(location.search)
+  querystringParams.set(key, value)
+  return querystringParams.toString()
+}
+
 export function addQuerystringToPath (path, querystringParams) {
   // The weird query needed to ignore empty arrays but allow for boolean values and numbers
   querystringParams = omitBy(x => isEmpty(x) && x !== true && !isNumber(x), querystringParams)

--- a/src/util/navigation.test.js
+++ b/src/util/navigation.test.js
@@ -4,8 +4,17 @@ import {
   gotoExternalUrl,
   editPostUrl,
   duplicatePostUrl,
-  setQuerystringParam
+  setQuerystringParam,
+  removeGroupFromUrl,
+  createUrl,
+  postCommentUrl,
+  messagePersonUrl,
+  isPublicPath,
+  isMapView,
+  isGroupsView,
+  origin
 } from './navigation'
+import { host } from 'config'
 
 describe('postUrl', () => {
   it('should default to displaying the all groups context', () => {
@@ -17,6 +26,12 @@ describe('postUrl', () => {
   it('should show a group context when group groupSlug is passed', () => {
     const expected = '/groups/awesome-team/post/123'
     const actual = postUrl('123', { context: 'groups', groupSlug: 'awesome-team' })
+    expect(actual).toEqual(expected)
+  })
+
+  it('should show the public group when public group groupSlug is passed', () => {
+    const expected = '/public/post/123'
+    const actual = postUrl('123', { groupSlug: 'public' })
     expect(actual).toEqual(expected)
   })
 
@@ -63,6 +78,13 @@ describe('removePostFromUrl', () => {
   })
 })
 
+describe('removeGroupFromUrl', () => {
+  it('should remove group/slug from groupDetail URL', () => {
+    const result = removeGroupFromUrl('/groups/test/group/test')
+    expect(result).toEqual('/groups/test')
+  })
+})
+
 describe('editPostUrl', () => {
   it('should return edit action URL with postId', () => {
     const result = editPostUrl('1234', { context: 'groups', groupSlug: 'test' })
@@ -102,5 +124,76 @@ describe('setQuerystringParam', () => {
   it('take empty search and add param', () => {
     const actual = setQuerystringParam('t', 'whatsit', {})
     expect(actual).toEqual('t=whatsit')
+  })
+})
+
+describe('origin with windows === undefined', () => {
+  const { window } = global
+  beforeAll(() => {
+    delete global.window
+  })
+
+  afterAll(() => {
+    global.window = window
+  })
+
+  it('returns host', () => {
+    const actual = origin()
+    expect(actual).toEqual(host)
+  })
+})
+
+describe('origin with windows !== undefined', () => {
+  it('returns window.location.origin', () => {
+    const actual = origin()
+    expect(actual).toEqual(window.location.origin)
+  })
+})
+
+describe('createUrl', () => {
+  it('returns correct location', () => {
+    const expected = '/my/create?lat=1.23456&lng=6.54321'
+    const actual = createUrl({ context: 'my' }, { lat: '1.23456', lng: '6.54321' })
+    expect(actual).toEqual(expected)
+  })
+})
+
+describe('postCommentUrl', () => {
+  it('returns correct path', () => {
+    const expected = '/all/post/123/comments/456'
+    const actual = postCommentUrl({ postId: '123', commentId: '456' })
+    expect(actual).toEqual(expected)
+  })
+})
+
+describe('messagePersonUrl', () => {
+  it('returns message thread path without participant search param', () => {
+    const expected = '/messages/456'
+    const actual = messagePersonUrl({ id: '123', messageThreadId: '456' })
+    expect(actual).toEqual(expected)
+  })
+
+  it('returns new messages path when no messageThreadId', () => {
+    const expected = '/messages/new?participants=123'
+    const actual = messagePersonUrl({ id: '123' })
+    expect(actual).toEqual(expected)
+  })
+})
+
+describe('is* functions', () => {
+  it('identifies map view (isMapView)', () => {
+    expect(isMapView('something/map/else')).toBe(true)
+    expect(isMapView('something/else')).toBe(false)
+  })
+
+  it('identifies group view (isGroupView', () => {
+    expect(isGroupsView('something/groups/else')).toBe(true)
+    expect(isGroupsView('something/else')).toBe(false)
+  })
+
+  it('identifies public path (isPublicPath', () => {
+    expect(isPublicPath('/public/something/else')).toBe(true)
+    expect(isPublicPath('something/public/else')).toBe(false)
+    expect(isPublicPath('something/else/public')).toBe(false)
   })
 })

--- a/src/util/navigation.test.js
+++ b/src/util/navigation.test.js
@@ -3,7 +3,8 @@ import {
   postUrl,
   gotoExternalUrl,
   editPostUrl,
-  duplicatePostUrl
+  duplicatePostUrl,
+  setQuerystringParam
 } from './navigation'
 
 describe('postUrl', () => {
@@ -84,5 +85,22 @@ describe('gotoExternalUrl', () => {
     gotoExternalUrl(testUrl)
     expect(window.open).toHaveBeenCalledWith(testUrl, null, 'noopener,noreferrer')
     window.open = jsDomWindowOpen
+  })
+})
+
+describe('setQuerystringParam', () => {
+  it('should add param while keeping search params', () => {
+    const actual = setQuerystringParam('t', 'whatsit', { search: '?q=wisywig' })
+    expect(actual).toEqual('q=wisywig&t=whatsit')
+  })
+
+  it('should replace param while keeping search params', () => {
+    const actual = setQuerystringParam('t', 'whatsit', { search: '?q=wisywig&t=whosit' })
+    expect(actual).toEqual('q=wisywig&t=whatsit')
+  })
+
+  it('take empty search and add param', () => {
+    const actual = setQuerystringParam('t', 'whatsit', {})
+    expect(actual).toEqual('t=whatsit')
   })
 })


### PR DESCRIPTION
Fixes #1610:

- Preserve `fromPostId` in search query param string for duplicated posts while editing
- Adds new function `setQuerystringParam` to support this preservation
- No new tests added (requiresintegration test?)