### PR TITLE
Fix bug preventing image deletion on post

### DIFF
--- a/src/components/AttachmentManager/AttachmentManager.js
+++ b/src/components/AttachmentManager/AttachmentManager.js
@@ -164,10 +164,9 @@ export function ImagePreview (props) {
   }
 
   return (
-    <div styleName='image-preview' ref={setNodeRef} style={style} {...listeners} {...attributes}>
-      <div style={bgImageStyle(attachment.url)} styleName='image'>
-        <Icon name='Ex' styleName='remove-image' onClick={removeImage} />
-      </div>
+    <div styleName='image-preview' ref={setNodeRef} style={style}>
+      <Icon name='Ex' styleName='remove-image' onClick={removeImage} />
+      <div style={bgImageStyle(attachment.url)} styleName='image' {...listeners} {...attributes} />
     </div>
   )
 }

--- a/src/components/AttachmentManager/AttachmentManager.scss
+++ b/src/components/AttachmentManager/AttachmentManager.scss
@@ -43,6 +43,7 @@
 
 .image-preview {
   composes: image-box;
+  position: relative;
   cursor: move;
 }
 
@@ -50,7 +51,7 @@
   composes: image-box;
   background-size: cover;
   background-position: center;
-  position: relative;
+  // position: relative;
   padding: 8px;
 }
 

--- a/src/components/AttachmentManager/AttachmentManager.scss
+++ b/src/components/AttachmentManager/AttachmentManager.scss
@@ -51,7 +51,6 @@
   composes: image-box;
   background-size: cover;
   background-position: center;
-  // position: relative;
   padding: 8px;
 }
 

--- a/src/components/AttachmentManager/AttachmentManager.store.js
+++ b/src/components/AttachmentManager/AttachmentManager.store.js
@@ -141,7 +141,7 @@ export default function reducer (state = defaultState, action) {
     case REMOVE_ATTACHMENT:
       return {
         ...state,
-        [attachmentKey]: reject(attachment, attachmentsForKey)
+        [attachmentKey]: reject({ url: attachment.url }, attachmentsForKey)
       }
     case MOVE_ATTACHMENT: {
       const { position1, position2 } = payload

--- a/src/components/AttachmentManager/__snapshots__/AttachmentManager.test.js.snap
+++ b/src/components/AttachmentManager/__snapshots__/AttachmentManager.test.js.snap
@@ -534,46 +534,44 @@ Object {
     id="root"
   >
     <div
-      aria-describedby=""
-      aria-disabled="false"
-      aria-pressed="true"
-      aria-roledescription="sortable"
       data-stylename="image-preview"
-      role="button"
-      tabindex="0"
     >
+      <span
+        class="icon-Ex"
+        data-stylename="icon"
+      />
       <div
+        aria-describedby=""
+        aria-disabled="false"
+        aria-pressed="true"
+        aria-roledescription="sortable"
         data-stylename="image"
+        role="button"
         style="background-image: url(https://nowhere/foo.zng);"
-      >
-        <span
-          class="icon-Ex"
-          data-stylename="icon"
-        />
-      </div>
+        tabindex="0"
+      />
     </div>
   </div>,
   "container": <div
     id="root"
   >
     <div
-      aria-describedby=""
-      aria-disabled="false"
-      aria-pressed="true"
-      aria-roledescription="sortable"
       data-stylename="image-preview"
-      role="button"
-      tabindex="0"
     >
+      <span
+        class="icon-Ex"
+        data-stylename="icon"
+      />
       <div
+        aria-describedby=""
+        aria-disabled="false"
+        aria-pressed="true"
+        aria-roledescription="sortable"
         data-stylename="image"
+        role="button"
         style="background-image: url(https://nowhere/foo.zng);"
-      >
-        <span
-          class="icon-Ex"
-          data-stylename="icon"
-        />
-      </div>
+        tabindex="0"
+      />
     </div>
   </div>,
   "debug": [Function],


### PR DESCRIPTION
fixes #1616 

Discovered that the 'X' delete icon was wrapped in the draggable image element. This prevented the click event from firing to delete the image.

After fixing the click event bug, I still could not delete a single image (it would delete all images) so I discovered that the `reject` method wasn't working properly with all the hash keys being passed in, so I isolated the `url` key and that fixed the problem. I didn't create any tests (other than updating the snapshot) but hand tested it with multiple images, sorting, and file attachments and it worked as expected.