### PR TITLE
show post images in carousel v0.1

### DIFF
--- a/src/components/PostImageAttachments/PostImageAttachments.js
+++ b/src/components/PostImageAttachments/PostImageAttachments.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { filter, isEmpty } from 'lodash/fp'
+import Slider from 'react-slick'
+
+import 'slick-carousel/slick/slick.css'
+import 'slick-carousel/slick/slick-theme.css'
+import './PostImageAttachments.scss'
+
+export default function PostImageAttachments ({
+  attachments
+}) {
+  const imageAttachments = filter({ type: 'image' }, attachments)
+
+  if (isEmpty(imageAttachments)) return null
+
+  const settings = {
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 1,
+    arrows: true,
+    slidesToScroll: 1
+  }
+
+  return (
+    <div styleName='images'>
+      <Slider {...settings}>
+        {imageAttachments.map(image => <img key={image.id} src={image.url} />)}
+      </Slider>
+    </div>
+  )
+}
+
+PostImageAttachments.propTypes = {
+  attachments: PropTypes.array.isRequired
+}

--- a/src/components/PostImageAttachments/PostImageAttachments.scss
+++ b/src/components/PostImageAttachments/PostImageAttachments.scss
@@ -1,0 +1,21 @@
+.images {
+  img {
+    width: 100%;
+    margin: 0 auto;
+  }
+
+  :global(.slick-slide) {
+    display: inline-block;
+    vertical-align: middle;
+    float: none;
+  }
+
+  :global(.slick-prev:before),
+  :global(.slick-next:before) {
+    text-shadow: 0px 0px 5px black;
+  }
+
+  :global(.slick-dots) {
+    bottom: 0px;
+  }
+}

--- a/src/components/PostImageAttachments/PostImageAttachments.test.js
+++ b/src/components/PostImageAttachments/PostImageAttachments.test.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import PostImageAttachments from './PostImageAttachments'
+import { shallow } from 'enzyme'
+
+it('renders a single image', () => {
+  expect(shallow(<PostImageAttachments attachments={[
+    { url: 'foo', type: 'image' }
+  ]} />)).toMatchSnapshot()
+})
+
+it('renders multiple images', () => {
+  expect(shallow(<PostImageAttachments attachments={[
+    { url: 'bar', type: 'image' },
+    { url: 'baz', type: 'image' },
+    { url: 'bonk', type: 'image' },
+    { url: 'bonk', type: 'file' }
+  ]} />)).toMatchSnapshot()
+})

--- a/src/components/PostImageAttachments/__snapshots__/PostImageAttachments.test.js.snap
+++ b/src/components/PostImageAttachments/__snapshots__/PostImageAttachments.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a single image 1`] = `
+<div
+  data-stylename="images"
+>
+  <Slider
+    arrows={true}
+    dots={true}
+    infinite={true}
+    slidesToScroll={1}
+    slidesToShow={1}
+    speed={500}
+  >
+    <img
+      src="foo"
+    />
+  </Slider>
+</div>
+`;
+
+exports[`renders multiple images 1`] = `
+<div
+  data-stylename="images"
+>
+  <Slider
+    arrows={true}
+    dots={true}
+    infinite={true}
+    slidesToScroll={1}
+    slidesToShow={1}
+    speed={500}
+  >
+    <img
+      src="bar"
+    />
+    <img
+      src="baz"
+    />
+    <img
+      src="bonk"
+    />
+  </Slider>
+</div>
+`;

--- a/src/components/PostImageAttachments/index.js
+++ b/src/components/PostImageAttachments/index.js
@@ -1,0 +1,3 @@
+import component from './PostImageAttachments'
+
+export default component

--- a/src/routes/PostDetail/PostDetail.js
+++ b/src/routes/PostDetail/PostDetail.js
@@ -8,7 +8,7 @@ import { Helmet } from 'react-helmet'
 import { AnalyticsEvents, TextHelpers } from 'hylo-shared'
 import { DETAIL_COLUMN_ID, position } from 'util/scrolling'
 import { PROJECT_CONTRIBUTIONS } from 'config/featureFlags'
-import CardImageAttachments from 'components/CardImageAttachments'
+import PostImageAttachments from 'components/PostImageAttachments'
 import {
   PostBody,
   PostFooter,
@@ -206,7 +206,7 @@ class PostDetail extends Component {
                 />
               </div>
             )}
-            <CardImageAttachments attachments={post.attachments} linked />
+            <PostImageAttachments attachments={post.attachments} linked />
             {isEvent && (
               <EventBody
                 styleName='body'


### PR DESCRIPTION
closes #1606 

This is a draft, here's what the carousel looks like -- we should discuss over zoom, I did it the most simple way I could.

### Post opens like this
<img width="569" alt="Screenshot 2024-04-16 at 11 35 55 PM" src="https://github.com/Hylozoic/hylo-evo/assets/5772/8430a06e-d52f-4b86-9001-a2b9907ff07c">

### After clicking the right arrow
<img width="573" alt="Screenshot 2024-04-16 at 11 36 05 PM" src="https://github.com/Hylozoic/hylo-evo/assets/5772/481d8b87-96bc-4085-8543-3b444b2058b0">

### Clicking the right arrow again
<img width="573" alt="Screenshot 2024-04-16 at 11 36 14 PM" src="https://github.com/Hylozoic/hylo-evo/assets/5772/5ac93ead-2d1f-49cd-b44c-bc4961729775">

### Click the right arrow again and it wraps around to the first image

(not shown, see above)