### PR TITLE
Evo 1654 fix prev and next arrows on slick photo carousel

### DIFF
--- a/src/components/ImageCarousel/ImageCarousel.js
+++ b/src/components/ImageCarousel/ImageCarousel.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Slider from 'react-slick'
 import { filter, isEmpty } from 'lodash/fp'
@@ -25,8 +25,37 @@ export default function ImageCarousel ({
     initialSlide: parseInt(initialSlide)
   }
 
+  const carouselRef = useRef()
+
+  const eventMouseclick = new window.MouseEvent('click', {
+    view: window,
+    bubbles: true,
+    cancelable: true
+  })
+
+  const prev = () => {
+    return carouselRef.current.querySelector('.slick-arrow.slick-prev')?.dispatchEvent(eventMouseclick)
+  }
+
+  const next = () => {
+    return carouselRef.current.querySelector('.slick-arrow.slick-next')?.dispatchEvent(eventMouseclick)
+  }
+
+  const handleKeydown = event => {
+    if (event.code === 'ArrowLeft') prev()
+    if (event.code === 'ArrowRight') next()
+  }
+
+  useEffect(() => {
+    carouselRef.current.addEventListener('keydown', handleKeydown)
+
+    return () => {
+      carouselRef.current.removeEventListener('keydown', handleKeydown)
+    }
+  }, [])
+
   return (
-    <div styleName='images'>
+    <div styleName='images' ref={carouselRef}>
       <Slider {...settings}>
         {imageAttachments.map((image, index) =>
           <div className={styles.imageWrapper} key={index} data-testid={`sc-img${index}`}>

--- a/src/components/ModalDialog/ModalDialog.js
+++ b/src/components/ModalDialog/ModalDialog.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, createRef } from 'react'
 import { withTranslation } from 'react-i18next'
 import { bool, func, node, string } from 'prop-types'
 
@@ -61,13 +61,31 @@ class ModalDialog extends Component {
     useNotificationFormat: false
   }
 
+  modalRef = createRef()
+
+  handleKeydown = event => {
+    if (event.code === 'Escape') this.submit()
+    if (event.code === 'Enter') this.cancel()
+  }
+
+  handleMousedown = event => {
+    if (!this.modalRef.current.contains(event.target)) this.cancel()
+  }
+
   componentDidMount () {
+    if (this.modalRef.current) { // for testing via shallow render
+      this.modalRef.current.querySelector("[tabindex='-1']").focus()
+      this.modalRef.current.addEventListener('keydown', this.handleKeydown)
+    }
+    document.addEventListener('mousedown', this.handleMousedown)
     // disable main window scrolling
     this.previousOverflowStyle = document.body.style.overflow
     document.body.style.overflow = 'hidden'
   }
 
   componentWillUnmount () {
+    this.modalRef.current.removeEventListener('keydown', this.handleKeydown)
+    document.removeEventListener('mousedown', this.handleMousedown)
     // re-enable main window scrolling
     document.body.style.overflow = this.previousOverflowStyle
   }
@@ -109,8 +127,8 @@ class ModalDialog extends Component {
     const showControls = showCancelButton || showSubmitButton
 
     return (
-      <div styleName='popup'>
-        <div styleName='popup-inner' style={innerStyle}>
+      <div styleName='popup' tabIndex='-1'>
+        <div styleName='popup-inner' style={innerStyle} ref={this.modalRef}>
           <span onClick={this.cancel} styleName='close-btn'>
             <Icon name='Ex' styleName='icon' />
           </span>

--- a/src/components/ModalDialog/__snapshots__/ModalDialog.test.js.snap
+++ b/src/components/ModalDialog/__snapshots__/ModalDialog.test.js.snap
@@ -3,6 +3,7 @@
 exports[`ModalDialog matches the last snapshot (useNotificationFormat) 1`] = `
 <div
   data-stylename="popup"
+  tabIndex="-1"
 >
   <div
     data-stylename="popup-inner"
@@ -70,6 +71,7 @@ exports[`ModalDialog matches the last snapshot (useNotificationFormat) 1`] = `
 exports[`ModalDialog matches the last snapshot 1`] = `
 <div
   data-stylename="popup"
+  tabIndex="-1"
 >
   <div
     data-stylename="popup-inner"

--- a/src/components/PostCard/PostHeader/PostHeader.js
+++ b/src/components/PostCard/PostHeader/PostHeader.js
@@ -12,6 +12,7 @@ import PostLabel from 'components/PostLabel'
 import Highlight from 'components/Highlight'
 import FlagContent from 'components/FlagContent'
 import Icon from 'components/Icon'
+import Tooltip from 'components/Tooltip'
 import PostCompletion from '../PostCompletion'
 import { personUrl, topicUrl } from 'util/navigation'
 import { TextHelpers } from 'hylo-shared'
@@ -147,7 +148,7 @@ class PostHeader extends PureComponent {
                 ))}
               </div>
               <div styleName='timestampRow'>
-                <span styleName='timestamp'>
+                <span styleName='timestamp' data-for='dateTip' data-tip={moment(createdAt).format('llll')}>
                   {TextHelpers.humanDate(createdAt)}
                 </span>
                 {announcement && <span styleName='announcementSection'>
@@ -212,6 +213,11 @@ class PostHeader extends PureComponent {
           effect='solid'
           delayShow={0}
           id='announcement-tt'
+        />
+        <Tooltip
+          delay={550}
+          id='dateTip'
+          position='left'
         />
       </div>
     )

--- a/src/components/PostCard/PostHeader/PostHeader.test.js
+++ b/src/components/PostCard/PostHeader/PostHeader.test.js
@@ -10,6 +10,8 @@ jest.mock('react-i18next', () => ({
   }
 }))
 
+Date.now = jest.fn(() => new Date(Date.UTC(2024, 6, 23, 16, 30)).valueOf())
+
 it('matches snapshot', () => {
   const creator = {
     name: 'JJ',

--- a/src/components/PostCard/PostHeader/__snapshots__/PostHeader.test.js.snap
+++ b/src/components/PostCard/PostHeader/__snapshots__/PostHeader.test.js.snap
@@ -62,7 +62,7 @@ exports[`matches announcement snapshot 1`] = `
           <span
             data-for="dateTip"
             data-stylename="timestamp"
-            data-tip="Tue, Jul 23, 2024 8:56 PM"
+            data-tip="Tue, Jul 23, 2024 12:30 PM"
           />
           <span
             data-stylename="announcementSection"
@@ -167,7 +167,7 @@ exports[`matches announcement snapshot 2`] = `
           <span
             data-for="dateTip"
             data-stylename="timestamp"
-            data-tip="Tue, Jul 23, 2024 8:56 PM"
+            data-tip="Tue, Jul 23, 2024 12:30 PM"
           />
           <span
             data-stylename="announcementSection"
@@ -276,7 +276,7 @@ exports[`matches announcement snapshot 3`] = `
           <span
             data-for="dateTip"
             data-stylename="timestamp"
-            data-tip="Tue, Jul 23, 2024 8:56 PM"
+            data-tip="Tue, Jul 23, 2024 12:30 PM"
           />
           <span
             data-stylename="announcementSection"
@@ -401,7 +401,7 @@ exports[`matches snapshot 1`] = `
           <span
             data-for="dateTip"
             data-stylename="timestamp"
-            data-tip="Tue, Jul 23, 2024 8:56 PM"
+            data-tip="Tue, Jul 23, 2024 12:30 PM"
           />
         </div>
       </div>
@@ -488,7 +488,7 @@ exports[`matches snapshot 2`] = `
           <span
             data-for="dateTip"
             data-stylename="timestamp"
-            data-tip="Tue, Jul 23, 2024 8:56 PM"
+            data-tip="Tue, Jul 23, 2024 12:30 PM"
           />
         </div>
       </div>
@@ -579,7 +579,7 @@ exports[`matches snapshot 3`] = `
           <span
             data-for="dateTip"
             data-stylename="timestamp"
-            data-tip="Tue, Jul 23, 2024 8:56 PM"
+            data-tip="Tue, Jul 23, 2024 12:30 PM"
           />
         </div>
       </div>
@@ -686,7 +686,7 @@ exports[`renders human readable dates 1`] = `
           <span
             data-for="dateTip"
             data-stylename="timestamp"
-            data-tip="Tue, Jul 23, 2024 8:56 PM"
+            data-tip="Tue, Jul 23, 2024 12:30 PM"
           />
         </div>
       </div>
@@ -783,7 +783,7 @@ exports[`renders human readable dates 2`] = `
           <span
             data-for="dateTip"
             data-stylename="timestamp"
-            data-tip="Tue, Jul 23, 2024 8:56 PM"
+            data-tip="Tue, Jul 23, 2024 12:30 PM"
           />
         </div>
       </div>
@@ -880,7 +880,7 @@ exports[`renders human readable dates 3`] = `
           <span
             data-for="dateTip"
             data-stylename="timestamp"
-            data-tip="Tue, Jul 23, 2024 8:56 PM"
+            data-tip="Tue, Jul 23, 2024 12:30 PM"
           />
         </div>
       </div>

--- a/src/components/PostCard/PostHeader/__snapshots__/PostHeader.test.js.snap
+++ b/src/components/PostCard/PostHeader/__snapshots__/PostHeader.test.js.snap
@@ -60,7 +60,9 @@ exports[`matches announcement snapshot 1`] = `
           data-stylename="timestampRow"
         >
           <span
+            data-for="dateTip"
             data-stylename="timestamp"
+            data-tip="Tue, Jul 23, 2024 8:56 PM"
           />
           <span
             data-stylename="announcementSection"
@@ -117,6 +119,11 @@ exports[`matches announcement snapshot 1`] = `
     insecure={true}
     resizeHide={true}
     wrapper="div"
+  />
+  <Tooltip
+    delay={550}
+    id="dateTip"
+    position="left"
   />
 </div>
 `;
@@ -158,7 +165,9 @@ exports[`matches announcement snapshot 2`] = `
           data-stylename="timestampRow"
         >
           <span
+            data-for="dateTip"
             data-stylename="timestamp"
+            data-tip="Tue, Jul 23, 2024 8:56 PM"
           />
           <span
             data-stylename="announcementSection"
@@ -219,6 +228,11 @@ exports[`matches announcement snapshot 2`] = `
     insecure={true}
     resizeHide={true}
     wrapper="div"
+  />
+  <Tooltip
+    delay={550}
+    id="dateTip"
+    position="left"
   />
 </div>
 `;
@@ -260,7 +274,9 @@ exports[`matches announcement snapshot 3`] = `
           data-stylename="timestampRow"
         >
           <span
+            data-for="dateTip"
             data-stylename="timestamp"
+            data-tip="Tue, Jul 23, 2024 8:56 PM"
           />
           <span
             data-stylename="announcementSection"
@@ -338,6 +354,11 @@ exports[`matches announcement snapshot 3`] = `
     resizeHide={true}
     wrapper="div"
   />
+  <Tooltip
+    delay={550}
+    id="dateTip"
+    position="left"
+  />
 </div>
 `;
 
@@ -378,7 +399,9 @@ exports[`matches snapshot 1`] = `
           data-stylename="timestampRow"
         >
           <span
+            data-for="dateTip"
             data-stylename="timestamp"
+            data-tip="Tue, Jul 23, 2024 8:56 PM"
           />
         </div>
       </div>
@@ -417,6 +440,11 @@ exports[`matches snapshot 1`] = `
     insecure={true}
     resizeHide={true}
     wrapper="div"
+  />
+  <Tooltip
+    delay={550}
+    id="dateTip"
+    position="left"
   />
 </div>
 `;
@@ -458,7 +486,9 @@ exports[`matches snapshot 2`] = `
           data-stylename="timestampRow"
         >
           <span
+            data-for="dateTip"
             data-stylename="timestamp"
+            data-tip="Tue, Jul 23, 2024 8:56 PM"
           />
         </div>
       </div>
@@ -502,6 +532,11 @@ exports[`matches snapshot 2`] = `
     resizeHide={true}
     wrapper="div"
   />
+  <Tooltip
+    delay={550}
+    id="dateTip"
+    position="left"
+  />
 </div>
 `;
 
@@ -542,7 +577,9 @@ exports[`matches snapshot 3`] = `
           data-stylename="timestampRow"
         >
           <span
+            data-for="dateTip"
             data-stylename="timestamp"
+            data-tip="Tue, Jul 23, 2024 8:56 PM"
           />
         </div>
       </div>
@@ -602,6 +639,11 @@ exports[`matches snapshot 3`] = `
     resizeHide={true}
     wrapper="div"
   />
+  <Tooltip
+    delay={550}
+    id="dateTip"
+    position="left"
+  />
 </div>
 `;
 
@@ -642,7 +684,9 @@ exports[`renders human readable dates 1`] = `
           data-stylename="timestampRow"
         >
           <span
+            data-for="dateTip"
             data-stylename="timestamp"
+            data-tip="Tue, Jul 23, 2024 8:56 PM"
           />
         </div>
       </div>
@@ -691,6 +735,11 @@ exports[`renders human readable dates 1`] = `
     insecure={true}
     resizeHide={true}
     wrapper="div"
+  />
+  <Tooltip
+    delay={550}
+    id="dateTip"
+    position="left"
   />
 </div>
 `;
@@ -732,7 +781,9 @@ exports[`renders human readable dates 2`] = `
           data-stylename="timestampRow"
         >
           <span
+            data-for="dateTip"
             data-stylename="timestamp"
+            data-tip="Tue, Jul 23, 2024 8:56 PM"
           />
         </div>
       </div>
@@ -782,6 +833,11 @@ exports[`renders human readable dates 2`] = `
     resizeHide={true}
     wrapper="div"
   />
+  <Tooltip
+    delay={550}
+    id="dateTip"
+    position="left"
+  />
 </div>
 `;
 
@@ -822,7 +878,9 @@ exports[`renders human readable dates 3`] = `
           data-stylename="timestampRow"
         >
           <span
+            data-for="dateTip"
             data-stylename="timestamp"
+            data-tip="Tue, Jul 23, 2024 8:56 PM"
           />
         </div>
       </div>
@@ -871,6 +929,11 @@ exports[`renders human readable dates 3`] = `
     insecure={true}
     resizeHide={true}
     wrapper="div"
+  />
+  <Tooltip
+    delay={550}
+    id="dateTip"
+    position="left"
   />
 </div>
 `;

--- a/src/components/Widget/Widget.scss
+++ b/src/components/Widget/Widget.scss
@@ -226,7 +226,7 @@
 }
 
 :global(.slick-prev) {
-  left: 15px;
+  left: 10px;
   z-index: 100;
 }
 

--- a/src/routes/PostDetail/Comments/Comment/Comment.js
+++ b/src/routes/PostDetail/Comments/Comment/Comment.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import { Link } from 'react-router-dom'
+import moment from 'moment-timezone'
 import { filter, isFunction } from 'lodash/fp'
 import { withTranslation } from 'react-i18next'
 import { TextHelpers } from 'hylo-shared'
@@ -110,7 +111,7 @@ export class Comment extends Component {
         <div styleName='header'>
           <Avatar avatarUrl={creator.avatarUrl} url={profileUrl} styleName='avatar' />
           <Link to={profileUrl} styleName='userName'>{creator.name}</Link>
-          <span styleName='timestamp'>
+          <span styleName='timestamp' data-for='dateTip' data-tip={moment(createdAt).format('llll')}>
             {editing && 'Editing now'}
             {!editing && TextHelpers.humanDate(createdAt)}
           </span>
@@ -262,6 +263,11 @@ export class CommentWithReplies extends Component {
           </div>
         )}
         <Tooltip id={`reply-tip-${comment.id}`} />
+        <Tooltip
+          delay={550}
+          id='dateTip'
+          position='left'
+        />
       </div>
     )
   }

--- a/src/routes/PostDetail/Comments/Comment/__snapshots__/Comment.test.js.snap
+++ b/src/routes/PostDetail/Comments/Comment/__snapshots__/Comment.test.js.snap
@@ -19,7 +19,9 @@ exports[`Comment displays image attachments 1`] = `
       Joe Smith
     </Link>
     <span
+      data-for="dateTip"
       data-stylename="timestamp"
+      data-tip="Tue, Jan 31, 2023 7:00 PM"
     >
       1 year ago
     </span>
@@ -149,7 +151,9 @@ exports[`Comment displays the delete menu when deleteComment is defined 1`] = `
       Joe Smith
     </Link>
     <span
+      data-for="dateTip"
       data-stylename="timestamp"
+      data-tip="Tue, Jan 31, 2023 7:00 PM"
     >
       1 year ago
     </span>
@@ -273,7 +277,9 @@ exports[`Comment displays the remove menu when removeComment is defined 1`] = `
       Joe Smith
     </Link>
     <span
+      data-for="dateTip"
       data-stylename="timestamp"
+      data-tip="Tue, Jan 31, 2023 7:00 PM"
     >
       1 year ago
     </span>
@@ -388,7 +394,9 @@ exports[`Comment does not display the delete menu when deleteComment is not defi
       Joe Smith
     </Link>
     <span
+      data-for="dateTip"
       data-stylename="timestamp"
+      data-tip="Tue, Jan 31, 2023 7:00 PM"
     >
       1 year ago
     </span>
@@ -494,7 +502,9 @@ exports[`Comment does not display the remove menu when removeComment is not defi
       Joe Smith
     </Link>
     <span
+      data-for="dateTip"
       data-stylename="timestamp"
+      data-tip="Tue, Jan 31, 2023 7:00 PM"
     >
       1 year ago
     </span>
@@ -618,7 +628,9 @@ exports[`Comment renders correctly 1`] = `
       Joe Smith
     </Link>
     <span
+      data-for="dateTip"
       data-stylename="timestamp"
+      data-tip="Tue, Jan 31, 2023 7:00 PM"
     >
       1 year ago
     </span>
@@ -724,7 +736,9 @@ exports[`Comment renders correctly when editing 1`] = `
       Joe Smith
     </Link>
     <span
+      data-for="dateTip"
       data-stylename="timestamp"
+      data-tip="Tue, Jan 31, 2023 7:00 PM"
     >
       Editing now
     </span>


### PR DESCRIPTION
fixes #1654 

Three commits:
- fix position of arrows on image carousel
- add modal keyboard and mouse events
-- previously, only the background DOM received events
-- escape now cancels the modal
-- return now submits the modal (NOTE: if no submit action, just closes modal)
-- clicking anywhere outside the modal cancels it
- add image carousel keyboard events
-- previously, only the background DOM received events
-- after above commit, modal received events but not image carousel
-- NOTE: only way to trigger slick-slide without a ref is to trigger mouse events on the arrow buttons

Best I could do quickly -- may have been a cleaner way to do it but eh