### PR TITLE
Evo 1667 image carousel not listening to keyboard events

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "yarn start",
     "start": "rm -rf ./node_modules/.cache/babel-loader && node --preserve-symlinks scripts/start.js",
     "build": "node --max-old-space-size=4000 scripts/build.js --stats && scripts/build-es5.sh",
-    "test": "node scripts/test.js",
+    "test": "TZ=UTC node scripts/test.js",
     "lint": "yarn exec standard",
     "lint:fix": "yarn exec standard --fix",
     "server": "./node_modules/.bin/babel-node --config-file ./babel.config.js scripts/serveUniversal.js",

--- a/src/components/AttachmentManager/AttachmentManager.scss
+++ b/src/components/AttachmentManager/AttachmentManager.scss
@@ -52,6 +52,9 @@
   background-size: cover;
   background-position: center;
   padding: 8px;
+  > img {
+    width: 100%;
+  }
 }
 
 .remove-image {

--- a/src/components/CardImageAttachments/CardImageAttachments.scss
+++ b/src/components/CardImageAttachments/CardImageAttachments.scss
@@ -1,20 +1,18 @@
 .image {
   position: relative;
   cursor: pointer;
-
-  img {
+  > img {
     width: 100%;
   }
 }
 
 .others {
   position: absolute;
-  width: 100%;
   bottom: 15px;
   right: 0;
   display: flex;
   overflow-x: auto;
-  padding: 10px 0;
+  padding: 10px 10px;
   padding-left: $space-2x;
   cursor: pointer;
 }

--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -90,7 +90,7 @@ export default function PostCard (props) {
             hasImage={hasImage}
           />
         </div>
-        <div onClick={onClick}>
+        <div>
           <CardImageAttachments attachments={post.attachments} />
         </div>
         {isEvent && (

--- a/src/components/PostCard/__snapshots__/PostCard.test.js.snap
+++ b/src/components/PostCard/__snapshots__/PostCard.test.js.snap
@@ -79,9 +79,7 @@ exports[`renders as expected 1`] = `
         updatedAt="2014-01-17T00:00:00.000Z"
       />
     </div>
-    <div
-      onClick={[Function]}
-    >
+    <div>
       <CardImageAttachments
         attachments={
           Array [

--- a/src/routes/PostDetail/Comments/Comment/Comment.test.js
+++ b/src/routes/PostDetail/Comments/Comment/Comment.test.js
@@ -3,6 +3,8 @@ import { shallow } from 'enzyme'
 import React from 'react'
 
 describe('Comment', () => {
+  Date.now = jest.fn(() => new Date(2024, 6, 23, 16, 30))
+
   const props = {
     comment: {
       text: '<p>text of the comment</p>',
@@ -12,7 +14,7 @@ describe('Comment', () => {
         avatarUrl: 'foo.jpg'
       },
       attachments: [],
-      createdAt: new Date('2023-02-01'),
+      createdAt: Date.now(),
       childComments: []
     },
     canModerate: false,

--- a/src/routes/PostDetail/Comments/Comment/Comment.test.js
+++ b/src/routes/PostDetail/Comments/Comment/Comment.test.js
@@ -2,6 +2,13 @@ import { Comment } from './Comment'
 import { shallow } from 'enzyme'
 import React from 'react'
 
+// local timezone is UTC so snapshots on CI match dev machines
+describe('Timezone', () => {
+  it('should always be UTC', () => {
+    expect(new Date().getTimezoneOffset()).toBe(0)
+  })
+})
+
 describe('Comment', () => {
   Date.now = jest.fn(() => new Date(2024, 6, 23, 16, 30))
 

--- a/src/routes/PostDetail/Comments/Comment/__snapshots__/Comment.test.js.snap
+++ b/src/routes/PostDetail/Comments/Comment/__snapshots__/Comment.test.js.snap
@@ -21,9 +21,9 @@ exports[`Comment displays image attachments 1`] = `
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Tue, Jul 23, 2024 4:30 PM"
     >
-      Commented 1 year ago
+      Commented 2w ago
     </span>
     <div
       data-stylename="upperRight"
@@ -52,7 +52,7 @@ exports[`Comment displays image attachments 1`] = `
                 },
               ],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2024-07-23T20:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -114,7 +114,7 @@ exports[`Comment displays image attachments 1`] = `
           },
         ],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2024-07-23T20:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -153,9 +153,9 @@ exports[`Comment displays the delete menu when deleteComment is defined 1`] = `
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Tue, Jul 23, 2024 4:30 PM"
     >
-      Commented 1 year ago
+      Commented 2w ago
     </span>
     <div
       data-stylename="upperRight"
@@ -197,7 +197,7 @@ exports[`Comment displays the delete menu when deleteComment is defined 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2024-07-23T20:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -240,7 +240,7 @@ exports[`Comment displays the delete menu when deleteComment is defined 1`] = `
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2024-07-23T20:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -279,9 +279,9 @@ exports[`Comment displays the remove menu when removeComment is defined 1`] = `
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Tue, Jul 23, 2024 4:30 PM"
     >
-      Commented 1 year ago
+      Commented 2w ago
     </span>
     <div
       data-stylename="upperRight"
@@ -314,7 +314,7 @@ exports[`Comment displays the remove menu when removeComment is defined 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2024-07-23T20:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -357,7 +357,7 @@ exports[`Comment displays the remove menu when removeComment is defined 1`] = `
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2024-07-23T20:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -396,9 +396,9 @@ exports[`Comment does not display the delete menu when deleteComment is not defi
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Tue, Jul 23, 2024 4:30 PM"
     >
-      Commented 1 year ago
+      Commented 2w ago
     </span>
     <div
       data-stylename="upperRight"
@@ -422,7 +422,7 @@ exports[`Comment does not display the delete menu when deleteComment is not defi
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2024-07-23T20:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -465,7 +465,7 @@ exports[`Comment does not display the delete menu when deleteComment is not defi
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2024-07-23T20:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -504,9 +504,9 @@ exports[`Comment does not display the remove menu when removeComment is not defi
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Tue, Jul 23, 2024 4:30 PM"
     >
-      Commented 1 year ago
+      Commented 2w ago
     </span>
     <div
       data-stylename="upperRight"
@@ -548,7 +548,7 @@ exports[`Comment does not display the remove menu when removeComment is not defi
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2024-07-23T20:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -591,7 +591,7 @@ exports[`Comment does not display the remove menu when removeComment is not defi
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2024-07-23T20:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -630,9 +630,9 @@ exports[`Comment renders correctly 1`] = `
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Tue, Jul 23, 2024 4:30 PM"
     >
-      Commented 1 year ago
+      Commented 2w ago
     </span>
     <div
       data-stylename="upperRight"
@@ -656,7 +656,7 @@ exports[`Comment renders correctly 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2024-07-23T20:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -699,7 +699,7 @@ exports[`Comment renders correctly 1`] = `
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2024-07-23T20:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -738,7 +738,7 @@ exports[`Comment renders correctly when editing 1`] = `
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Tue, Jul 23, 2024 4:30 PM"
     >
       Editing now
     </span>
@@ -769,7 +769,7 @@ exports[`Comment renders correctly when editing 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2024-07-23T20:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,

--- a/src/routes/PostDetail/Comments/Comment/__snapshots__/Comment.test.js.snap
+++ b/src/routes/PostDetail/Comments/Comment/__snapshots__/Comment.test.js.snap
@@ -52,7 +52,7 @@ exports[`Comment displays image attachments 1`] = `
                 },
               ],
               "childComments": Array [],
-              "createdAt": 2024-07-23T20:30:00.000Z,
+              "createdAt": 2024-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -114,7 +114,7 @@ exports[`Comment displays image attachments 1`] = `
           },
         ],
         "childComments": Array [],
-        "createdAt": 2024-07-23T20:30:00.000Z,
+        "createdAt": 2024-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -197,7 +197,7 @@ exports[`Comment displays the delete menu when deleteComment is defined 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2024-07-23T20:30:00.000Z,
+              "createdAt": 2024-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -240,7 +240,7 @@ exports[`Comment displays the delete menu when deleteComment is defined 1`] = `
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2024-07-23T20:30:00.000Z,
+        "createdAt": 2024-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -314,7 +314,7 @@ exports[`Comment displays the remove menu when removeComment is defined 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2024-07-23T20:30:00.000Z,
+              "createdAt": 2024-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -357,7 +357,7 @@ exports[`Comment displays the remove menu when removeComment is defined 1`] = `
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2024-07-23T20:30:00.000Z,
+        "createdAt": 2024-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -422,7 +422,7 @@ exports[`Comment does not display the delete menu when deleteComment is not defi
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2024-07-23T20:30:00.000Z,
+              "createdAt": 2024-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -465,7 +465,7 @@ exports[`Comment does not display the delete menu when deleteComment is not defi
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2024-07-23T20:30:00.000Z,
+        "createdAt": 2024-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -548,7 +548,7 @@ exports[`Comment does not display the remove menu when removeComment is not defi
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2024-07-23T20:30:00.000Z,
+              "createdAt": 2024-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -591,7 +591,7 @@ exports[`Comment does not display the remove menu when removeComment is not defi
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2024-07-23T20:30:00.000Z,
+        "createdAt": 2024-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -656,7 +656,7 @@ exports[`Comment renders correctly 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2024-07-23T20:30:00.000Z,
+              "createdAt": 2024-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -699,7 +699,7 @@ exports[`Comment renders correctly 1`] = `
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2024-07-23T20:30:00.000Z,
+        "createdAt": 2024-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -769,7 +769,7 @@ exports[`Comment renders correctly when editing 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2024-07-23T20:30:00.000Z,
+              "createdAt": 2024-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,

--- a/src/store/presenters/__snapshots__/presentPost.test.js.snap
+++ b/src/store/presenters/__snapshots__/presentPost.test.js.snap
@@ -15,7 +15,7 @@ Object {
       "response": "yes",
     },
   ],
-  "exactTimestamp": "Tue, Jul 23, 2024 12:30 PM",
+  "exactTimestamp": "Tue, Jul 23, 2024 4:30 PM",
   "fileAttachments": Array [],
   "groups": Array [],
   "id": 324,

--- a/src/store/presenters/presentPost.test.js
+++ b/src/store/presenters/presentPost.test.js
@@ -12,7 +12,7 @@ describe('presentPost', () => {
   const eventInvitation = session.EventInvitation.create({ response: 'yes', person, event: postId })
   session.Post.create({ id: postId, postMemberships: [postMembership], eventInvitations: [eventInvitation] })
 
-  Date.now = jest.fn(() => new Date(Date.UTC(2024, 6, 23, 16, 30)).valueOf())
+  Date.now = jest.fn(() => new Date(2024, 6, 23, 16, 30))
 
   it('matches the snapshot', () => {
     const post = session.Post.withId(postId)


### PR DESCRIPTION
Closed #1667 

Two commits:
- removed an onClick that overrode the CardImageAttachments onClick
  - this means that clicking an image on a PostCard opens the ImageCarousel modal and not the PostDetail slide-out (so this might not be the way we want it to behave, we may want it to open the PostDetails and require another click/touch to open the ImageCarousel modal)
- fix a WebKit bug that caused the "others" thumbnail images to stretch