### PR TITLE
Evo 1673 tests failing ci due to timezone difference

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "yarn start",
     "start": "rm -rf ./node_modules/.cache/babel-loader && node --preserve-symlinks scripts/start.js",
     "build": "node --max-old-space-size=4000 scripts/build.js --stats && scripts/build-es5.sh",
-    "test": "node scripts/test.js",
+    "test": "TZ=UTC node scripts/test.js",
     "lint": "yarn exec standard",
     "lint:fix": "yarn exec standard --fix",
     "server": "./node_modules/.bin/babel-node --config-file ./babel.config.js scripts/serveUniversal.js",

--- a/src/components/PostCard/PostHeader/PostHeader.test.js
+++ b/src/components/PostCard/PostHeader/PostHeader.test.js
@@ -11,7 +11,7 @@ jest.mock('react-i18next', () => ({
   }
 }))
 
-Date.now = jest.fn(() => new Date(Date.UTC(2024, 6, 23, 16, 30)).valueOf())
+Date.now = jest.fn(() => new Date(2024, 6, 23, 16, 30))
 
 it('matches snapshot', () => {
   const creator = {

--- a/src/routes/PostDetail/Comments/Comment/Comment.test.js
+++ b/src/routes/PostDetail/Comments/Comment/Comment.test.js
@@ -2,7 +2,24 @@ import { Comment } from './Comment'
 import { shallow } from 'enzyme'
 import React from 'react'
 
+// local timezone is UTC so snapshots on CI match dev machines
+describe('Timezone', () => {
+  it('should always be UTC', () => {
+    expect(new Date().getTimezoneOffset()).toBe(0)
+  })
+})
+
 describe('Comment', () => {
+  const createdAt = new Date(2023, 6, 23, 16, 30)
+  const epochTime = createdAt.getTime() // 'just now' for humanDate in snapshots
+  beforeAll(() => {
+    jest.spyOn(Date.prototype, 'getTime').mockImplementation(() => epochTime)
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
   const props = {
     comment: {
       text: '<p>text of the comment</p>',
@@ -12,7 +29,7 @@ describe('Comment', () => {
         avatarUrl: 'foo.jpg'
       },
       attachments: [],
-      createdAt: new Date('2023-02-01'),
+      createdAt: createdAt,
       childComments: []
     },
     canModerate: false,

--- a/src/routes/PostDetail/Comments/Comment/__snapshots__/Comment.test.js.snap
+++ b/src/routes/PostDetail/Comments/Comment/__snapshots__/Comment.test.js.snap
@@ -21,9 +21,9 @@ exports[`Comment displays image attachments 1`] = `
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Sun, Jul 23, 2023 4:30 PM"
     >
-      Commented 1 year ago
+      Commented just now
     </span>
     <div
       data-stylename="upperRight"
@@ -52,7 +52,7 @@ exports[`Comment displays image attachments 1`] = `
                 },
               ],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2023-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -114,7 +114,7 @@ exports[`Comment displays image attachments 1`] = `
           },
         ],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2023-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -153,9 +153,9 @@ exports[`Comment displays the delete menu when deleteComment is defined 1`] = `
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Sun, Jul 23, 2023 4:30 PM"
     >
-      Commented 1 year ago
+      Commented just now
     </span>
     <div
       data-stylename="upperRight"
@@ -197,7 +197,7 @@ exports[`Comment displays the delete menu when deleteComment is defined 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2023-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -240,7 +240,7 @@ exports[`Comment displays the delete menu when deleteComment is defined 1`] = `
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2023-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -279,9 +279,9 @@ exports[`Comment displays the remove menu when removeComment is defined 1`] = `
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Sun, Jul 23, 2023 4:30 PM"
     >
-      Commented 1 year ago
+      Commented just now
     </span>
     <div
       data-stylename="upperRight"
@@ -314,7 +314,7 @@ exports[`Comment displays the remove menu when removeComment is defined 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2023-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -357,7 +357,7 @@ exports[`Comment displays the remove menu when removeComment is defined 1`] = `
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2023-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -396,9 +396,9 @@ exports[`Comment does not display the delete menu when deleteComment is not defi
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Sun, Jul 23, 2023 4:30 PM"
     >
-      Commented 1 year ago
+      Commented just now
     </span>
     <div
       data-stylename="upperRight"
@@ -422,7 +422,7 @@ exports[`Comment does not display the delete menu when deleteComment is not defi
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2023-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -465,7 +465,7 @@ exports[`Comment does not display the delete menu when deleteComment is not defi
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2023-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -504,9 +504,9 @@ exports[`Comment does not display the remove menu when removeComment is not defi
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Sun, Jul 23, 2023 4:30 PM"
     >
-      Commented 1 year ago
+      Commented just now
     </span>
     <div
       data-stylename="upperRight"
@@ -548,7 +548,7 @@ exports[`Comment does not display the remove menu when removeComment is not defi
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2023-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -591,7 +591,7 @@ exports[`Comment does not display the remove menu when removeComment is not defi
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2023-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -630,9 +630,9 @@ exports[`Comment renders correctly 1`] = `
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Sun, Jul 23, 2023 4:30 PM"
     >
-      Commented 1 year ago
+      Commented just now
     </span>
     <div
       data-stylename="upperRight"
@@ -656,7 +656,7 @@ exports[`Comment renders correctly 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2023-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,
@@ -699,7 +699,7 @@ exports[`Comment renders correctly 1`] = `
       Object {
         "attachments": Array [],
         "childComments": Array [],
-        "createdAt": 2023-02-01T00:00:00.000Z,
+        "createdAt": 2023-07-23T16:30:00.000Z,
         "creator": Object {
           "avatarUrl": "foo.jpg",
           "id": 1,
@@ -738,7 +738,7 @@ exports[`Comment renders correctly when editing 1`] = `
     <span
       data-for="dateTip"
       data-stylename="timestamp"
-      data-tip="Tue, Jan 31, 2023 7:00 PM"
+      data-tip="Sun, Jul 23, 2023 4:30 PM"
     >
       Editing now
     </span>
@@ -769,7 +769,7 @@ exports[`Comment renders correctly when editing 1`] = `
             Object {
               "attachments": Array [],
               "childComments": Array [],
-              "createdAt": 2023-02-01T00:00:00.000Z,
+              "createdAt": 2023-07-23T16:30:00.000Z,
               "creator": Object {
                 "avatarUrl": "foo.jpg",
                 "id": 1,

--- a/src/store/presenters/__snapshots__/presentPost.test.js.snap
+++ b/src/store/presenters/__snapshots__/presentPost.test.js.snap
@@ -15,7 +15,7 @@ Object {
       "response": "yes",
     },
   ],
-  "exactTimestamp": "Tue, Jul 23, 2024 12:30 PM",
+  "exactTimestamp": "Tue, Jul 23, 2024 4:30 PM",
   "fileAttachments": Array [],
   "groups": Array [],
   "id": 324,

--- a/src/store/presenters/presentPost.test.js
+++ b/src/store/presenters/presentPost.test.js
@@ -12,7 +12,7 @@ describe('presentPost', () => {
   const eventInvitation = session.EventInvitation.create({ response: 'yes', person, event: postId })
   session.Post.create({ id: postId, postMemberships: [postMembership], eventInvitations: [eventInvitation] })
 
-  Date.now = jest.fn(() => new Date(Date.UTC(2024, 6, 23, 16, 30)).valueOf())
+  Date.now = jest.fn(() => new Date(2024, 6, 23, 16, 30))
 
   it('matches the snapshot', () => {
     const post = session.Post.withId(postId)


### PR DESCRIPTION
Closes #1673 

Two commits:
- Force tests to run in UTC timezone
- Update tests to generate snapshots in UTC timezone and force humanDate in snapshots to remain "just now" so running tests in the future won't fail
