### PR TITLE
Evo 1672 image carousel opening when post is clicked in card view

### DIFF
--- a/src/components/CardImageAttachments/CardImageAttachments.js
+++ b/src/components/CardImageAttachments/CardImageAttachments.js
@@ -21,6 +21,7 @@ export default function CardImageAttachments ({
   const [initialSlide, setInitialSlide] = useState(0)
   const [modalVisible, setModalVisible] = useState(false)
   const toggleModal = (e) => {
+    if (className === 'postCard') return
     setInitialSlide(e?.target.dataset.index || 0)
     setModalVisible(!modalVisible)
   }

--- a/src/components/CardImageAttachments/CardImageAttachments.js
+++ b/src/components/CardImageAttachments/CardImageAttachments.js
@@ -21,7 +21,7 @@ export default function CardImageAttachments ({
   const [initialSlide, setInitialSlide] = useState(0)
   const [modalVisible, setModalVisible] = useState(false)
   const toggleModal = (e) => {
-    if (className === 'postCard') return
+    if (className === 'post-card') return
     setInitialSlide(e?.target.dataset.index || 0)
     setModalVisible(!modalVisible)
   }

--- a/src/components/CardImageAttachments/CardImageAttachments.test.js
+++ b/src/components/CardImageAttachments/CardImageAttachments.test.js
@@ -58,7 +58,7 @@ it('does not displays modal when image is clicked from postCard', async () => {
     { url: 'bar', type: 'image' },
     { url: 'baz', type: 'image' },
     { url: 'bonk', type: 'image' }
-  ]} className='postCard' />)
+  ]} className='post-card' />)
 
   userEvent.click(await screen.findByAltText('Attached image 1'))
   await expect(() => screen.getByTestId('sc-img0')).toThrow('Unable to find an element by: [data-testid="sc-img0"]')

--- a/src/components/CardImageAttachments/CardImageAttachments.test.js
+++ b/src/components/CardImageAttachments/CardImageAttachments.test.js
@@ -52,3 +52,16 @@ it('displays modal when image is clicked', async () => {
   expect(((await screen.findAllByTestId('sc-img1'))[0]).parentNode.parentNode).toHaveAttribute('aria-hidden', 'false')
   expect(((await screen.findAllByTestId('sc-img2'))[0]).parentNode.parentNode).toHaveAttribute('aria-hidden', 'true')
 })
+
+it('does not displays modal when image is clicked from postCard', async () => {
+  render(<CardImageAttachments attachments={[
+    { url: 'bar', type: 'image' },
+    { url: 'baz', type: 'image' },
+    { url: 'bonk', type: 'image' }
+  ]} className='postCard' />)
+
+  userEvent.click(await screen.findByAltText('Attached image 2'))
+  expect((await screen.findAllByTestId('sc-img0')).length).toBe(0)
+  expect((await screen.findAllByTestId('sc-img1')).length).toBe(0)
+  expect((await screen.findAllByTestId('sc-img2')).length).toBe(0)
+})

--- a/src/components/CardImageAttachments/CardImageAttachments.test.js
+++ b/src/components/CardImageAttachments/CardImageAttachments.test.js
@@ -60,8 +60,6 @@ it('does not displays modal when image is clicked from postCard', async () => {
     { url: 'bonk', type: 'image' }
   ]} className='postCard' />)
 
-  userEvent.click(await screen.findByAltText('Attached image 2'))
-  expect((await screen.findAllByTestId('sc-img0')).length).toBe(0)
-  expect((await screen.findAllByTestId('sc-img1')).length).toBe(0)
-  expect((await screen.findAllByTestId('sc-img2')).length).toBe(0)
+  userEvent.click(await screen.findByAltText('Attached image 1'))
+  await expect(() => screen.getByTestId('sc-img0')).toThrow('Unable to find an element by: [data-testid="sc-img0"]')
 })

--- a/src/components/ImageCarousel/ImageCarousel.js
+++ b/src/components/ImageCarousel/ImageCarousel.js
@@ -34,7 +34,7 @@ export default function ImageCarousel ({
   }
 
   return (
-    <div styleName='images' ref={carouselRef} onKeydown={handleKeydown}>
+    <div styleName='images' ref={carouselRef} onKeyDown={handleKeydown}>
       <Slider ref={slickRef} {...settings}>
         {imageAttachments.map((image, index) =>
           <div className={styles.imageWrapper} key={index} data-testid={`sc-img${index}`}>

--- a/src/components/ImageCarousel/__snapshots__/ImageCarousel.test.js.snap
+++ b/src/components/ImageCarousel/__snapshots__/ImageCarousel.test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders a single image 1`] = `
 <div
   data-stylename="images"
-  onKeydown={[Function]}
+  onKeyDown={[Function]}
 >
   <Slider
     adaptiveHeight={true}
@@ -31,7 +31,7 @@ exports[`renders a single image 1`] = `
 exports[`renders multiple images 1`] = `
 <div
   data-stylename="images"
-  onKeydown={[Function]}
+  onKeyDown={[Function]}
 >
   <Slider
     adaptiveHeight={true}

--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -91,7 +91,7 @@ export default function PostCard (props) {
           />
         </div>
         <div onClick={onClick}>
-          <CardImageAttachments attachments={post.attachments} className='postCard' />
+          <CardImageAttachments attachments={post.attachments} className='post-card' />
         </div>
         {isEvent && (
           <div styleName='bodyWrapper'>

--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -91,7 +91,7 @@ export default function PostCard (props) {
           />
         </div>
         <div onClick={onClick}>
-          <CardImageAttachments attachments={post.attachments} />
+          <CardImageAttachments attachments={post.attachments} className='postCard' />
         </div>
         {isEvent && (
           <div styleName='bodyWrapper'>

--- a/src/components/PostCard/__snapshots__/PostCard.test.js.snap
+++ b/src/components/PostCard/__snapshots__/PostCard.test.js.snap
@@ -91,7 +91,7 @@ exports[`renders as expected 1`] = `
             },
           ]
         }
-        className="postCard"
+        className="post-card"
       />
     </div>
     <div>

--- a/src/components/PostCard/__snapshots__/PostCard.test.js.snap
+++ b/src/components/PostCard/__snapshots__/PostCard.test.js.snap
@@ -91,6 +91,7 @@ exports[`renders as expected 1`] = `
             },
           ]
         }
+        className="postCard"
       />
     </div>
     <div>


### PR DESCRIPTION
Closes #1672 

- prevent ImageCarousel from opening when clicking an image attached to a PostCard
- correct a typo: change onKeydown to onKeyDown

Not sure why I hadn't noticed this typo before now, but including it here since it's tangentially involved.