### PR TITLE
return summary to Events and fix its test

### DIFF
--- a/src/components/PostCard/EventBody/EventBody.js
+++ b/src/components/PostCard/EventBody/EventBody.js
@@ -27,9 +27,8 @@ class EventBody extends Component {
     const { showInviteDialog } = this.state
     const { id, startTime, endTime, location, eventInvitations, groups } = event
 
-    const numAttachments = event.attachments.length || 0
-    const firstAttachment = numAttachments ? event.attachments[0] || 0 : null
-    const attachmentType = firstAttachment ? firstAttachment.type || 0 : null
+    const firstAttachment = event.attachments?.[0]
+    const attachmentType = firstAttachment?.type
 
     const eventAttendees = filter(ei => ei.response === RESPONSES.YES, eventInvitations)
 
@@ -62,7 +61,6 @@ class EventBody extends Component {
               onClick={onClick}
               constrained={constrained}
               expanded={expanded}
-              hideDetails={!expanded}
               slug={slug}
             />
           </div>

--- a/src/components/PostCard/EventBody/EventBody.test.js
+++ b/src/components/PostCard/EventBody/EventBody.test.js
@@ -12,7 +12,7 @@ jest.mock('react-i18next', () => ({
 }))
 
 describe('EventBody', () => {
-  it.skip('matches last snapshot', () => {
+  it('matches last snapshot', () => {
     const event = {
       startTime: moment(1551908483315),
       endTime: moment(1551919283315),

--- a/src/components/PostCard/EventBody/__snapshots__/EventBody.test.js.snap
+++ b/src/components/PostCard/EventBody/__snapshots__/EventBody.test.js.snap
@@ -3,13 +3,21 @@
 exports[`EventBody matches last snapshot 1`] = `
 <div
   className="external-class"
-  data-stylename="body"
+  data-stylename="body eventBody"
 >
-  <EventDate
-    endTime={"2019-03-07T00:41:23.315Z"}
-    location="Oakland"
-    startTime={"2019-03-06T21:41:23.315Z"}
-  />
+  <div
+    data-stylename="eventTop"
+  >
+    <div
+      data-stylename="calendarDate"
+    >
+      <EventDate
+        endTime={"2019-03-07T00:41:23.315Z"}
+        location="Oakland"
+        startTime={"2019-03-06T21:41:23.315Z"}
+      />
+    </div>
+  </div>
   <div
     data-stylename="eventBodyColumn"
   >
@@ -25,8 +33,8 @@ exports[`EventBody matches last snapshot 1`] = `
         data-stylename="icon"
         name="Clock"
       />
-
-      Wed, Mar 6 at 2:41PM - 5:41PM
+       
+      Wed, Mar 6, 2019 at 9:41PM - Thu, Mar 7 at 12:41AM GMT
     </div>
     <div
       data-stylename="eventData eventLocation"
@@ -35,23 +43,52 @@ exports[`EventBody matches last snapshot 1`] = `
         data-stylename="icon"
         name="Location"
       />
-
+       
       Oakland
     </div>
-    <PostDetails
-      endTime={"2019-03-07T00:41:23.315Z"}
-      expanded={true}
-      hideDetails={false}
-      location="Oakland"
-      slug="sluggo"
-      startTime={"2019-03-06T21:41:23.315Z"}
-    />
+    <div
+      data-stylename="eventDetails"
+    >
+      <PostDetails
+        endTime={"2019-03-07T00:41:23.315Z"}
+        expanded={true}
+        location="Oakland"
+        slug="sluggo"
+        startTime={"2019-03-06T21:41:23.315Z"}
+      />
+    </div>
   </div>
-  <EventRSVP
-    endTime={"2019-03-07T00:41:23.315Z"}
-    location="Oakland"
-    respondToEvent={[Function]}
-    startTime={"2019-03-06T21:41:23.315Z"}
+  <div
+    data-stylename="eventAttendance"
+  >
+    <div
+      data-stylename="people"
+    >
+      <div
+        data-stylename="fade"
+      />
+      <PeopleInfo
+        people={Array []}
+        peopleTotal={0}
+        phrases={
+          Object {
+            "emptyMessage": "No one is attending yet",
+            "mePhraseSingular": "are attending",
+            "phraseSingular": "is attending",
+            "pluralPhrase": "attending",
+          }
+        }
+      />
+    </div>
+  </div>
+  <EmojiRow
+    post={
+      Object {
+        "endTime": "2019-03-07T00:41:23.315Z",
+        "location": "Oakland",
+        "startTime": "2019-03-06T21:41:23.315Z",
+      }
+    }
   />
 </div>
 `;

--- a/src/components/PostCard/PostDetails/PostDetails.js
+++ b/src/components/PostCard/PostDetails/PostDetails.js
@@ -22,7 +22,6 @@ export default function PostDetails ({
   expanded,
   highlightProps,
   fileAttachments,
-  hideDetails,
   onClick,
   editedTimestamp,
   ...post
@@ -44,7 +43,7 @@ export default function PostDetails ({
         {linkPreview?.url && linkPreviewFeatured && isVideo && (
           <Feature url={linkPreview.url} />
         )}
-        {details && !hideDetails && (
+        {details && (
           <ClickCatcher groupSlug={slug}>
             <HyloHTML styleName='details' html={details} />
           </ClickCatcher>


### PR DESCRIPTION
Closes #1668 

Adding my notes here for posterity:

PostDetails uses the boolean `expanded` to control how much of the body to show. The same variable name is used elsewhere. The hideDetails was used in EventBody as a prop to PostDetails.

One commit:
* remove hideDetails and fix tests/code for EventBody