### PR TITLE
allow spaces in @ mentions

### DIFF
--- a/src/components/HyloEditor/extensions/PeopleMentions.js
+++ b/src/components/HyloEditor/extensions/PeopleMentions.js
@@ -40,6 +40,7 @@ export const PeopleMentions = ({ groupIds, maxSuggestions, onSelection, suggesti
       },
       suggestion: {
         char: '@',
+        allowSpaces: true,
         pluginKey: new PluginKey('mentionSuggestion'),
         render: () => suggestions.render(suggestionsThemeName),
         items: asyncDebounce(200, async ({ query, editor }) => {


### PR DESCRIPTION
Pretty easy, but doesn't klose 1379 completely, so leaving that issue open...

It's still a little wonky, in that esc and multiple spaces doesn't entirely close it. And if left alone (ie no selection), then typing can cause it to pop back up <HI, I'M MISTER MEESEEKS! LOOK AT ME!!>

I think it's good enough for now, ya? I'll work on these two things next and separately, if they seem like the right things to do:

* limit to top ten (by id asc) w/scroll bar after 6 or so items
* scope by groups somehow (will need input on this one)