### PR TITLE
Evo 1681 fix component changing an uncontrolled input warning

### DIFF
--- a/src/routes/GroupSettings/RolesSettingsTab/RolesSettingsTab.js
+++ b/src/routes/GroupSettings/RolesSettingsTab/RolesSettingsTab.js
@@ -477,15 +477,19 @@ export function RoleList ({ slug, fetchStewardSuggestions, addRoleToMember, sugg
   }, [])
 
   useEffect(() => {
+    let isMounted = true
     dispatch(responsbilityFetcher({ roleId }))
-      .then((response) => setResponsibilitiesForRole(response?.payload?.data?.responsibilities || []))
+      .then((response) => { if (isMounted) setResponsibilitiesForRole(response?.payload?.data?.responsibilities || []) })
       .catch((e) => { console.error('Error fetching responsibilities for role ', e) })
+    return () => { isMounted = false }
   }, [])
 
   useEffect(() => {
+    let isMounted = true
     dispatch(fetchResponsibilitiesForGroup({ groupId: group.id }))
-      .then((response) => setAvailableResponsibilities(response?.payload?.data?.responsibilities || []))
+      .then((response) => { if (isMounted) setAvailableResponsibilities(response?.payload?.data?.responsibilities || []) })
       .catch((e) => { console.error('Error fetching responsibilities for group', e) })
+    return () => { isMounted = false }
   }, [])
 
   const memberRoleIds = membersForRole.map(mr => mr.id)

--- a/src/routes/GroupWelcomeModal/GroupWelcomeModal.js
+++ b/src/routes/GroupWelcomeModal/GroupWelcomeModal.js
@@ -164,7 +164,7 @@ export default function GroupWelcomeModal (props) {
                           data-testid={'cbAgreement' + i}
                           value={i}
                           onChange={handleCheckAgreement}
-                          checked={currentAgreements[i]}
+                          checked={currentAgreements[i] || false}
                         />
                         <label htmlFor={'agreement' + agreement.id} styleName={cx('i-agree', { accepted: currentAgreements[i] })}>
                           {t('I agree to the above')}

--- a/src/routes/NonAuthLayoutRouter/Signup/FinishRegistration/FinishRegistration.test.js
+++ b/src/routes/NonAuthLayoutRouter/Signup/FinishRegistration/FinishRegistration.test.js
@@ -31,7 +31,7 @@ it('renders correctly', () => {
     { wrapper: currentUserProvider() }
   )
 
-  expect(screen.getByText('One more step!')).toBeInTheDocument()
+  expect(screen.getByText('One more step!')).toBeVisible()
 })
 
 it('renders password error if it not confirmed', async () => {
@@ -47,7 +47,7 @@ it('renders password error if it not confirmed', async () => {
   await user.type(screen.getByLabelText('passwordConfirmation'), '012345671')
   await user.click(screen.getByText('Jump in to Hylo!'))
 
-  expect(screen.getByText("Passwords don't match")).toBeInTheDocument()
+  expect(screen.getByText("Passwords don't match")).toBeVisible()
 })
 
 it('does not submit if name is not present, even if password is valid', async () => {
@@ -59,7 +59,7 @@ it('does not submit if name is not present, even if password is valid', async ()
       registerCalled(req.variables)
 
       // this return is required, results are ignored
-      return res(ctx.data({}))
+      return {}
     })
   )
 
@@ -84,7 +84,7 @@ it('registers user if a name and valid password provided', async () => {
       registerCalled(req.variables)
 
       // this return is required, results are ignored
-      return res(ctx.data({}))
+      return {}
     })
   )
 


### PR DESCRIPTION
Closes #1681 
Closes #1682 
Closes #1685 

Two commits:
* make sure input is initialized to a value and not undefined
* set a flag in useEffect to indicate component mounted and then unset it when the component unmounts.
* not sure this fixes it -- there seemed to be a race condition that intermittently caused a `console.log` warning that the component state was being changed that caused a "cannot log after test completes" warning resulting from `handleChange` being fired after the test completed